### PR TITLE
Remove unneeded warnings when FW2TAR_HASH is missing

### DIFF
--- a/src/fw2tar
+++ b/src/fw2tar
@@ -449,21 +449,25 @@ if __name__ == "__main__":
         sys.exit(1)
 
     fw2tar_hash_env = os.getenv("FW2TAR_HASH")
+
+    # if the environment variable isn't set we don't need to tell the user to reinstall,
+    # it means they're running from inside the docker container manually
     if fw2tar_hash_env is None:
         print("FW2TAR_HASH environment variable is not set.")
-    fw2tar_file = "/usr/local/src/fw2tar_wrapper"
-    fw2tar_hash = sha1sum_file(fw2tar_file)
+    else:
+        fw2tar_file = "/usr/local/src/fw2tar_wrapper"
+        fw2tar_hash = sha1sum_file(fw2tar_file)
 
-    if fw2tar_hash != fw2tar_hash_env:
-        print(
-            "Current fw2tar file does not match /usr/local/src/fw2tar_wrapper."
-        )
-        print(
-            'Reinstall global fw2tar from container with "docker run rehosting/fw2tar fw2tar_install | sudo sh"'
-        )
-        print(
-            'Reinstall local fw2tar from container with "docker run rehosting/fw2tar fw2tar_install.local | sh"'
-        )
+        if fw2tar_hash != fw2tar_hash_env:
+            print(
+                "Current fw2tar file does not match /usr/local/src/fw2tar_wrapper."
+            )
+            print(
+                'Reinstall global fw2tar from container with "docker run rehosting/fw2tar fw2tar_install | sudo sh"'
+            )
+            print(
+                'Reinstall local fw2tar from container with "docker run rehosting/fw2tar fw2tar_install.local | sh"'
+            )
 
     parser = argparse.ArgumentParser(description="Process some files.")
     parser.add_argument("firmware", type=str, help="Input file")


### PR DESCRIPTION
If there is no hash present, the user is running fw2tar directly within the container. Printing out the hash not matching is unnecessary--there's already a warning and the additional ones are mostly incorrect about what's going on or how to fix it.