### PR TITLE
dockerfile: poetry now uses "--only main"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN git clone --depth=1 https://github.com/davidribyrne/cramfs.git /cramfs && \
 
 # Clone unblob fork then install with poetry
 RUN git clone --depth=1 https://github.com/rehosting/unblob.git /unblob
-RUN cd /unblob && poetry install --no-dev
+RUN cd /unblob && poetry install --only main
 
 # Explicitly install unblob deps - mostly captured above, but some of the .debs get updated and installed via curl
 RUN sh -c /unblob/unblob/install-deps.sh


### PR DESCRIPTION
Had a recent failure on a clean fw2tar container build. Poetry has deprecated `--no-dev` and now uses `--only main`, this PR allowed the clean container to build.