### PR TITLE
log file naming consistent with output naming

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -64,7 +64,11 @@ pub fn extract_and_process(
 
     let extract_dir = temp_dir.path();
 
-    let log_file = out_file_base.with_extension(format!("{extractor_name}.log"));
+    let log_file = {
+        // Simple string append to avoid with_extension() being greedy
+        let file_name = out_file_base.file_name().unwrap().to_string_lossy();
+        out_file_base.with_file_name(format!("{}.{extractor_name}.log", file_name))
+    };
 
     let start_time = Instant::now();
 
@@ -96,7 +100,11 @@ pub fn extract_and_process(
             break;
         }
 
-        let tar_path = out_file_base.with_extension(format!("{extractor_name}.{i}.tar.gz"));
+        let tar_path = {
+            // Simple string append to avoid with_extension() being greedy
+            let file_name = out_file_base.file_name().unwrap().to_string_lossy();
+            out_file_base.with_file_name(format!("{}.{extractor_name}.{i}.tar.gz", file_name))
+        };
 
         // XXX: improve error handling here
         let file_node_count = tar_fs(&fs.path, &tar_path, metadata, removed_devices).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,13 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
         if removed_devices.is_empty() {
             log::warn!("No device files were found during extraction, skipping writing log");
         } else {
+            let devices_log_path = {
+                // Simple string append to avoid with_extension() being greedy
+                let file_name = output.file_name().unwrap().to_string_lossy();
+                output.with_file_name(format!("{}.devices.log", file_name))
+            };
             fs::write(
-                output.with_extension("devices.log"),
+                devices_log_path,
                 removed_devices.join("\n"),
             )
             .unwrap();


### PR DESCRIPTION
Same file name preservation change as #44 , but also for log file names:
```
-rw-r--r-- 1 root root 5362552 Jul 30 10:02 'WNAP320 Firmware Version 2.0.3.zip'
-rw-r--r-- 1 root root  341028 Jul 30 10:02 'WNAP320 Firmware Version 2.0.binwalkv3.log'
-rw-r--r-- 1 root root 5657312 Jul 30 10:02 'WNAP320 Firmware Version 2.0.3.rootfs.tar.gz'
-rw-r--r-- 1 root root 2077274 Jul 30 10:02 'WNAP320 Firmware Version 2.0.unblob.log'
-rw-r--r-- 1 root root    4211 Jul 30 10:02 'WNAP320 Firmware Version 2.0.binwalk.log'
-rw-r--r-- 1 root root 5599495 Jul 30 10:02 'WNAP320 Firmware Version 2.0.unblob.0.tar.gz'
-rw-r--r-- 1 root root 5599495 Jul 30 10:02 'WNAP320 Firmware Version 2.0.binwalk.0.tar.gz'
```

becomes
```
-rw-r--r-- 1 root root 5362552 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.zip'
-rw-r--r-- 1 root root  340180 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.binwalkv3.log'
-rw-r--r-- 1 root root    4211 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.binwalk.log'
-rw-r--r-- 1 root root 5657314 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.rootfs.tar.gz'
-rw-r--r-- 1 root root 2077266 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.unblob.log'
-rw-r--r-- 1 root root 5599497 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.binwalk.0.tar.gz'
-rw-r--r-- 1 root root 5599497 Jul 30 10:19 'WNAP320 Firmware Version 2.0.3.unblob.0.tar.gz'
```