### PR TITLE
add arm64 builds to docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
     bzip2 \
     cabextract \
     clang \
+    cmake \
     cpio \
     cramfsswap \
     curl \


### PR DESCRIPTION
This PR adds the necessary fixes to make the arm64 builds work for `fw2tar`. This change was all that was required to make the docker build succeed, but I still have the question of "what is the proper way to add arm64 image builds to CI?" since right now the actions are all ran on `rehosting-arc`.

There are a few options, I think the least work for you guys would be one of these two options:
- add a new CI yaml that performs the `publish.yaml` jobs logic without the `rehosting-arc` specific stuff
- add a matrix to the CI yaml's, and conditionally perform the `rehosting-arc` specific logic if the `runs-on:` matrix target is `rehosting-arc`

Would either of the above be something you are open to? My only real end goal here is to get `arm64` docker images of `fw2tar` pushed to dockerhub. In-house I'm building them fine but I don't want to have to continue to maintain different logic for `fw2tar` if I don't have to.

LMK and I can add the proper changeset!