### PR TITLE
Emit a versioned fw2tar manifest (in-tar trailer + sidecar)

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::Instant;
@@ -13,7 +12,7 @@ pub mod find_linux_filesystems;
 
 use crate::archive::tar_fs;
 use crate::extractors::{ExtractError, Extractor};
-use crate::metadata::Metadata;
+use crate::metadata::{Manifest, Metadata};
 use find_linux_filesystems::find_linux_filesystems;
 
 #[derive(Debug, Clone)]
@@ -26,6 +25,10 @@ pub struct ExtractionResult {
     pub archive_hash: String,
     pub file_node_count: usize,
     pub path: PathBuf,
+    /// The manifest embedded in this archive's trailer (input metadata,
+    /// extractor, stripped device nodes). Re-emitted as the sidecar for the
+    /// winning result.
+    pub manifest: Manifest,
 }
 
 #[derive(Error, Debug)]
@@ -50,7 +53,6 @@ pub fn extract_and_process(
     _secondary_limit: usize,
     results: &Mutex<Vec<ExtractionResult>>,
     metadata: &Metadata,
-    removed_devices: Option<&Mutex<HashSet<PathBuf>>>,
 ) -> Result<(), ExtractProcessError> {
     let extractor_name = extractor.name();
 
@@ -107,7 +109,8 @@ pub fn extract_and_process(
         };
 
         // XXX: improve error handling here
-        let file_node_count = tar_fs(&fs.path, &tar_path, metadata, removed_devices).unwrap();
+        let (file_node_count, manifest) =
+            tar_fs(&fs.path, &tar_path, metadata, extractor_name).unwrap();
         let archive_hash = sha1_file(&tar_path).unwrap();
 
         results.lock().unwrap().push(ExtractionResult {
@@ -119,6 +122,7 @@ pub fn extract_and_process(
             archive_hash,
             file_node_count,
             path: tar_path,
+            manifest,
         });
     }
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fs::{self, File};
 use std::io::{self, Cursor, Write};
 use std::iter;
@@ -9,11 +8,20 @@ use std::sync::Mutex;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use nix::unistd::{Gid, Group, Uid, User};
+use serde::{Deserialize, Serialize};
 use walkdir::{DirEntry, WalkDir};
 
-use crate::metadata::Metadata;
+use crate::metadata::{Manifest, Metadata};
 
 const FIXED_TIMESTAMP: u64 = 1546318800; // Tue Jan 01 2019 05:00:00 GMT+0000
+
+/// Trailing magic that marks an fw2tar manifest. Always the last 16 bytes of
+/// the decompressed gzip stream, so a reader can locate the manifest from the
+/// end regardless of tar size. Must stay exactly 16 bytes.
+pub const MANIFEST_MAGIC: &[u8; 16] = b"made with fw2tar";
+
+/// Version of the trailer *framing* (distinct from the manifest schema version).
+const TRAILER_FRAME_VERSION: u16 = 1;
 
 static BAD_PREFIXES: &[&str] = &["0.tar", "squashfs-root"];
 static BAD_SUFFIXES: &[&str] = &["_extract", ".uncompressed", ".unknown"];
@@ -25,34 +33,71 @@ fn is_extraction_artifact(name: &str) -> bool {
         || BAD_SUFFIXES.iter().any(|suffix| name.ends_with(suffix))
 }
 
-fn is_blk_or_chr(meta: fs::Metadata) -> bool {
-    meta.file_type().is_block_device() | meta.file_type().is_char_device()
+/// Character or block special file. Serialized as "char"/"block".
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DeviceKind {
+    Char,
+    Block,
+}
+
+/// The device kind for a node, else None for non-device file types.
+fn device_kind(ft: fs::FileType) -> Option<DeviceKind> {
+    if ft.is_char_device() {
+        Some(DeviceKind::Char)
+    } else if ft.is_block_device() {
+        Some(DeviceKind::Block)
+    } else {
+        None
+    }
+}
+
+/// A device node dropped from the archive payload. Penguin deliberately does
+/// not want raw char/block nodes in the rehosted filesystem (it recreates them
+/// with `mknod` post-extraction), so fw2tar strips them — but recording type +
+/// major/minor + mode in the manifest makes that strip non-lossy: a downstream
+/// consumer can replay them.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemovedDevice {
+    /// Path inside the rootfs, e.g. "/dev/console".
+    pub path: String,
+    pub kind: DeviceKind,
+    pub major: u64,
+    pub minor: u64,
+    /// Permission bits (incl. setuid/setgid/sticky), e.g. 0o600.
+    pub mode: u32,
 }
 
 pub fn tar_fs(
     rootfs_dir: &Path,
     tar_path: &Path,
     fw2tar_metadata: &Metadata,
-    removed_devices: Option<&Mutex<HashSet<PathBuf>>>,
-) -> io::Result<usize> {
+    extractor_name: &str,
+) -> io::Result<(usize, Manifest)> {
     let mut tar_entry_count = 0;
     let prefix_to_skip = rootfs_dir.components().count();
+    let removed_devices: Mutex<Vec<RemovedDevice>> = Mutex::new(Vec::new());
 
     let should_add_to_tar = |entry: &DirEntry| {
         if entry.path() == rootfs_dir {
             return true;
         }
 
-        if entry.metadata().map(is_blk_or_chr).unwrap_or(false) {
-            if let Some(removed_devices) = removed_devices {
-                let path = iter::once(Component::RootDir)
+        if let Ok(meta) = entry.metadata() {
+            if let Some(kind) = device_kind(meta.file_type()) {
+                let path: PathBuf = iter::once(Component::RootDir)
                     .chain(entry.path().components().skip(prefix_to_skip))
                     .collect();
-
-                removed_devices.lock().unwrap().insert(path);
+                let rdev = meta.rdev();
+                removed_devices.lock().unwrap().push(RemovedDevice {
+                    path: path.to_string_lossy().into_owned(),
+                    kind,
+                    major: libc::major(rdev) as u64,
+                    minor: libc::minor(rdev) as u64,
+                    mode: meta.permissions().mode() & 0o7777,
+                });
+                return false;
             }
-
-            return false;
         }
 
         entry
@@ -133,19 +178,134 @@ pub fn tar_fs(
 
     let mut encoder = tar.into_inner()?;
 
-    encoder.write_all(&[0; 0x10])?;
+    let manifest = Manifest::new(
+        fw2tar_metadata.clone(),
+        extractor_name,
+        removed_devices.into_inner().unwrap(),
+    );
 
-    let json_bytes = serde_json::to_vec(&fw2tar_metadata).unwrap();
+    write_manifest_trailer(&mut encoder, &manifest)?;
 
-    encoder.write_all(&json_bytes)?;
-    encoder.write_all(b"made with fw2tar")?;
+    Ok((tar_entry_count, manifest))
+}
 
-    Ok(tar_entry_count)
+/// Append the versioned manifest trailer to the gzip stream, after the tar's
+/// EOF blocks. Layout (in the *decompressed* view, written last in the stream):
+///
+/// ```text
+/// [ manifest JSON bytes ]
+/// [ u32 little-endian: len(JSON) ]
+/// [ u16 little-endian: TRAILER_FRAME_VERSION ]
+/// [ 16-byte MANIFEST_MAGIC ]
+/// ```
+///
+/// A reader gunzips the whole stream, checks the final 16 bytes against the
+/// magic, then reads the frame version and JSON length backwards from there.
+/// This is robust to tar size and to the trailer living in a separate gzip
+/// member (gzip concatenation decompresses transparently).
+pub fn write_manifest_trailer<W: Write>(writer: &mut W, manifest: &Manifest) -> io::Result<()> {
+    let json = serde_json::to_vec(manifest)?;
+    writer.write_all(&json)?;
+    writer.write_all(&(json.len() as u32).to_le_bytes())?;
+    writer.write_all(&TRAILER_FRAME_VERSION.to_le_bytes())?;
+    writer.write_all(MANIFEST_MAGIC)?;
+    Ok(())
+}
+
+/// Parse a manifest from the tail of a decompressed fw2tar stream (the inverse
+/// of `write_manifest_trailer`). Returns `None` if the magic is absent or the
+/// framing is malformed.
+pub fn parse_manifest_trailer(decompressed: &[u8]) -> Option<Manifest> {
+    let magic_len = MANIFEST_MAGIC.len();
+    // magic(16) + frame version(2) + json length(4)
+    let header = magic_len + 2 + 4;
+    if decompressed.len() < header {
+        return None;
+    }
+    let (rest, magic) = decompressed.split_at(decompressed.len() - magic_len);
+    if magic != MANIFEST_MAGIC {
+        return None;
+    }
+    let len_start = rest.len() - 6;
+    let _frame_version = u16::from_le_bytes([rest[len_start + 4], rest[len_start + 5]]);
+    let json_len = u32::from_le_bytes([
+        rest[len_start],
+        rest[len_start + 1],
+        rest[len_start + 2],
+        rest[len_start + 3],
+    ]) as usize;
+    let json_end = len_start;
+    let json_start = json_end.checked_sub(json_len)?;
+    serde_json::from_slice(&rest[json_start..json_end]).ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::is_extraction_artifact;
+    use super::{
+        is_extraction_artifact, parse_manifest_trailer, write_manifest_trailer, DeviceKind,
+        RemovedDevice,
+    };
+    use crate::metadata::{Manifest, Metadata, MANIFEST_VERSION};
+
+    fn sample_manifest() -> Manifest {
+        Manifest::new(
+            Metadata {
+                input_hash: "abc123".into(),
+                file: "firmware.bin".into(),
+                fw2tar_command: vec!["fw2tar".into(), "firmware.bin".into()],
+            },
+            "unblob",
+            vec![RemovedDevice {
+                path: "/dev/console".into(),
+                kind: DeviceKind::Char,
+                major: 5,
+                minor: 1,
+                mode: 0o600,
+            }],
+        )
+    }
+
+    #[test]
+    fn manifest_trailer_round_trips_from_the_end() {
+        // Simulate the decompressed stream: arbitrary leading bytes (the tar)
+        // followed by the trailer. Parsing must recover the manifest from the
+        // tail without knowing where the tar ends.
+        let mut buf: Vec<u8> = vec![0u8; 4096]; // stand-in for tar payload + EOF blocks
+        write_manifest_trailer(&mut buf, &sample_manifest()).unwrap();
+
+        let parsed = parse_manifest_trailer(&buf).expect("manifest should parse from the tail");
+        assert_eq!(parsed.version, MANIFEST_VERSION);
+        assert_eq!(parsed.extractor, "unblob");
+        assert_eq!(parsed.input.input_hash, "abc123");
+        assert_eq!(parsed.devices.len(), 1);
+        assert_eq!(parsed.devices[0].path, "/dev/console");
+        assert_eq!(parsed.devices[0].major, 5);
+    }
+
+    #[test]
+    fn parse_manifest_trailer_rejects_missing_magic() {
+        assert!(parse_manifest_trailer(b"not an fw2tar archive").is_none());
+        assert!(parse_manifest_trailer(&[]).is_none());
+    }
+
+    #[test]
+    fn removed_device_serializes_for_replay() {
+        // The manifest must carry everything needed to recreate the node.
+        let d = RemovedDevice {
+            path: "/dev/console".into(),
+            kind: DeviceKind::Char,
+            major: 5,
+            minor: 1,
+            mode: 0o600,
+        };
+        let j: serde_json::Value =
+            serde_json::from_slice(&serde_json::to_vec(&d).unwrap()).unwrap();
+        assert_eq!(j["path"], "/dev/console");
+        assert_eq!(j["kind"], "char");
+        assert_eq!(j["major"], 5);
+        assert_eq!(j["minor"], 1);
+        assert_eq!(j["mode"], 0o600);
+    }
 
     #[test]
     fn flags_bad_prefixes() {

--- a/src/args.rs
+++ b/src/args.rs
@@ -43,10 +43,6 @@ pub struct Args {
     #[arg(long)]
     pub wrapper_help: bool,
 
-    /// Create a file showing all the devices removed from any of the extractions
-    #[arg(long, alias("log_devices"))]
-    pub log_devices: bool,
-
     /// Timeout for extractors, measured in seconds
     #[arg(long, default_value_t = 20)]
     pub timeout: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,10 +7,9 @@ pub mod metadata;
 
 use analysis::{extract_and_process, ExtractionResult};
 pub use error::Fw2tarError;
-use metadata::Metadata;
+use metadata::{Manifest, Metadata};
 
 use std::cmp::Reverse;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::{env, fs, thread};
@@ -79,9 +78,6 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
 
     let results: Mutex<Vec<ExtractionResult>> = Mutex::new(Vec::new());
 
-    let removed_devices: Option<Mutex<HashSet<PathBuf>>> =
-        args.log_devices.then(|| Mutex::new(HashSet::new()));
-
     thread::scope(|threads| -> Result<(), Fw2tarError> {
         for extractor_name in extractors {
             let extractor = extractors::get_extractor(&extractor_name)
@@ -98,7 +94,6 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
                     args.secondary_limit,
                     &results,
                     &metadata,
-                    removed_devices.as_ref(),
                 ) {
                     log::info!("{} error: {e}", extractor.name());
                 }
@@ -108,50 +103,64 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
         Ok(())
     })?;
 
-    if let Some(removed_devices) = removed_devices {
-        let mut removed_devices = removed_devices
-            .into_inner()
-            .unwrap()
-            .into_iter()
-            .map(|path| path.to_string_lossy().into_owned())
-            .collect::<Vec<_>>();
-
-        removed_devices.sort();
-
-        if removed_devices.is_empty() {
-            log::warn!("No device files were found during extraction, skipping writing log");
-        } else {
-            let devices_log_path = {
-                // Simple string append to avoid with_extension() being greedy
-                let file_name = output.file_name().unwrap().to_string_lossy();
-                output.with_file_name(format!("{}.devices.log", file_name))
-            };
-            fs::write(
-                devices_log_path,
-                removed_devices.join("\n"),
-            )
-            .unwrap();
-        }
-    }
-
     let results = results.lock().unwrap();
     let mut best_results: Vec<_> = results.iter().filter(|&res| res.index == 0).collect();
 
     let result = if best_results.is_empty() {
         return Ok((BestExtractor::None, selected_output_path));
     } else if best_results.len() == 1 {
-        Ok((BestExtractor::Only(best_results[0].extractor), selected_output_path.clone()))
+        Ok((
+            BestExtractor::Only(best_results[0].extractor),
+            selected_output_path.clone(),
+        ))
     } else {
         best_results.sort_by_key(|res| Reverse((res.file_node_count, res.extractor == "unblob")));
 
-        Ok((BestExtractor::Best(best_results[0].extractor), selected_output_path.clone()))
+        Ok((
+            BestExtractor::Best(best_results[0].extractor),
+            selected_output_path.clone(),
+        ))
     };
 
     let best_result = best_results[0];
 
     fs::rename(&best_result.path, &selected_output_path).unwrap();
 
+    write_manifest_sidecar(&best_result.manifest, &selected_output_path);
+
     result
+}
+
+/// Write the chosen archive's manifest as a standalone `<archive>.manifest.json`
+/// sidecar (the same content embedded in the archive's gzip trailer), and warn
+/// about any device nodes that were stripped so the loss is never silent. The
+/// sidecar is best-effort: a failure to write it is logged, not fatal.
+fn write_manifest_sidecar(manifest: &Manifest, output: &Path) {
+    if !manifest.devices.is_empty() {
+        let in_dev = manifest
+            .devices
+            .iter()
+            .filter(|d| d.path.starts_with("/dev/"))
+            .count();
+        log::warn!(
+            "stripped {} device node(s) from the rootfs ({in_dev} under /dev) — see {}.manifest.json",
+            manifest.devices.len(),
+            output.display()
+        );
+    }
+
+    let sidecar_path = {
+        // Simple string append to avoid with_extension() being greedy.
+        let file_name = output.file_name().unwrap().to_string_lossy();
+        output.with_file_name(format!("{file_name}.manifest.json"))
+    };
+    match serde_json::to_vec_pretty(manifest) {
+        Ok(bytes) => match fs::write(&sidecar_path, bytes) {
+            Ok(()) => log::info!("wrote manifest sidecar {sidecar_path:?}"),
+            Err(e) => log::warn!("failed to write manifest sidecar {sidecar_path:?}: {e}"),
+        },
+        Err(e) => log::warn!("failed to serialize manifest: {e}"),
+    }
 }
 
 #[cfg(test)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,9 +1,60 @@
 use serde::{Deserialize, Serialize};
 
-/// Output archive metadata that is concatonated to the tar (inside the gzip)
+use crate::archive::RemovedDevice;
+
+/// Current manifest schema version. Bump only on an *incompatible* change;
+/// adding new optional fields is forward-compatible because readers ignore
+/// unknown keys, so it does not require a bump.
+pub const MANIFEST_VERSION: u32 = 1;
+
+/// Identifying information about the input firmware and the invocation that
+/// produced the archive. The field names (`file`, `input_hash`,
+/// `fw2tar_command`) are part of the on-disk format and are kept stable.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     pub input_hash: String,
     pub file: String,
     pub fw2tar_command: Vec<String>,
+}
+
+/// The versioned side-channel spec that fw2tar tacks onto its output: embedded
+/// in the gzip trailer after the tar EOF blocks (see `archive::write_manifest_trailer`)
+/// and also written verbatim as a `<archive>.manifest.json` sidecar. The tar
+/// payload itself stays a plain, consistently-extractable archive; everything a
+/// consumer (e.g. Penguin) needs to know *beyond* the payload lives here.
+///
+/// The input fields are flattened to the top level so the keys match the legacy
+/// trailer layout that `utils/show_metadata.py` and `utils/stitch` rely on.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Manifest {
+    /// Manifest schema version (`MANIFEST_VERSION`).
+    pub version: u32,
+
+    #[serde(flatten)]
+    pub input: Metadata,
+
+    /// Name of the extractor whose output was chosen (e.g. "unblob").
+    pub extractor: String,
+
+    /// Char/block device nodes stripped from the rootfs. Penguin recreates
+    /// these with `mknod` after extraction rather than carrying raw nodes in
+    /// the rehosted filesystem, so recording type + major/minor + mode makes
+    /// the strip non-lossy.
+    pub devices: Vec<RemovedDevice>,
+    // Reserved for future iterations (kept out of the emitted JSON until
+    // populated; adding them later is forward-compatible per the note above):
+    //   * `mounts` — where secondary filesystems would mount in the primary.
+    //   * `secondary_filesystems` — descriptors for (or payloads of) additional
+    //     candidate filesystems.
+}
+
+impl Manifest {
+    pub fn new(input: Metadata, extractor: &str, devices: Vec<RemovedDevice>) -> Self {
+        Self {
+            version: MANIFEST_VERSION,
+            input,
+            extractor: extractor.to_string(),
+            devices,
+        }
+    }
 }

--- a/utils/show_metadata.py
+++ b/utils/show_metadata.py
@@ -1,30 +1,54 @@
 #!/usr/bin/env python3
+"""Print the fw2tar manifest embedded in an output .rootfs.tar.gz.
+
+The manifest is a versioned JSON spec tacked onto the gzip stream after the tar
+EOF blocks (see src/archive.rs::write_manifest_trailer). Layout, in the
+decompressed view, written last in the stream:
+
+    [ manifest JSON bytes ]
+    [ u32 little-endian: len(JSON) ]
+    [ u16 little-endian: trailer-frame version ]
+    [ 16-byte magic b"made with fw2tar" ]
+"""
 import argparse
 import gzip
 import json
+import struct
+
+MAGIC = b"made with fw2tar"
+
+
+def read_manifest(firmware):
+    """Decompress `firmware` and parse the manifest from the tail."""
+    with gzip.open(firmware, "rb") as f:
+        data = f.read()
+
+    if len(data) < len(MAGIC) + 6 or data[-len(MAGIC):] != MAGIC:
+        raise ValueError("no fw2tar manifest trailer found")
+
+    rest = data[: -len(MAGIC)]
+    (frame_version,) = struct.unpack("<H", rest[-2:])
+    (json_len,) = struct.unpack("<I", rest[-6:-2])
+    json_bytes = rest[-6 - json_len : -6]
+    return frame_version, json.loads(json_bytes)
+
 
 def main(firmware):
-    with gzip.open(firmware, 'rb') as f:
-        f.seek(-0x1000, 2)
-        end_bytes = f.read()
-
-    str_len = list(end_bytes[::-1]).index(0)
-    string = end_bytes[-str_len:].decode()
-
-    metadata, magic = string.split('\n')
-    assert(magic == "made with fw2tar")
-
-    metadata = json.loads(metadata)
-
+    _frame_version, manifest = read_manifest(firmware)
 
     print("Made with fw2tar")
-    print(f"  File: {metadata['file']}")
-    print(f"  Generated with command: {metadata['fw2tar_command']}")
-    print(f"  Input file SHA1: {metadata['input_hash']}")
+    print(f"  Manifest version: {manifest.get('version')}")
+    print(f"  File: {manifest.get('file')}")
+    print(f"  Generated with command: {manifest.get('fw2tar_command')}")
+    print(f"  Input file SHA1: {manifest.get('input_hash')}")
+    print(f"  Extractor: {manifest.get('extractor')}")
+    devices = manifest.get("devices", [])
+    print(f"  Stripped device nodes: {len(devices)}")
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Show metadata from fw2tar output argive")
-    parser.add_argument("firmware", type=str, help="Output .tar.gz from fw2tar")
+    parser = argparse.ArgumentParser(description="Show metadata from an fw2tar output archive")
+    parser.add_argument("firmware", type=str, help="Output .rootfs.tar.gz from fw2tar")
 
     args = parser.parse_args()
 

--- a/utils/stitch/plan.py
+++ b/utils/stitch/plan.py
@@ -14,6 +14,7 @@ import gzip
 import hashlib
 import json
 import posixpath
+import struct
 import sys
 import tarfile
 from pathlib import Path
@@ -158,25 +159,31 @@ def apply_plan(
                     seen[new_name] = frag.source
                     members_written += 1
 
-    # fw2tar metadata trailer — see show_metadata.py and src/archive.rs. The
-    # trailer lives in the *decompressed* gzip view, after the tar EOF blocks.
-    # gzip supports multi-member concatenation, so we append a second gzip
-    # member that decompresses to: 16 nulls + json + "made with fw2tar".
-    metadata = {
+    # fw2tar manifest trailer — see show_metadata.py and src/archive.rs
+    # (write_manifest_trailer). The trailer lives in the *decompressed* gzip
+    # view, after the tar EOF blocks; gzip supports multi-member concatenation,
+    # so we append a second gzip member containing it. Framing (last in stream):
+    #   [ manifest JSON ][ u32 LE len(JSON) ][ u16 LE frame version ][ 16-byte magic ]
+    manifest = {
+        "version": 1,
         "file": str(out_path.name),
-        "fw2tar_command": "stitch (fw2tar.utils.stitch)",
+        "fw2tar_command": ["stitch (fw2tar.utils.stitch)"],
         "input_hash": plan_hash(plan),
+        "extractor": "stitch",
+        "devices": [],
+        # stitch-specific extras (readers ignore unknown keys):
         "stitched_from": [f.source for f in plan.fragments],
         "stitch_plan_confidence": plan.confidence,
     }
-    # Note the "\n" separator: show_metadata.py does string.split("\n") to split
-    # the json blob from the magic. archive.rs omits it (latent inconsistency
-    # between fw2tar and its own utility); we match show_metadata.py here so the
-    # existing tool keeps working on stitched outputs.
+    manifest_json = json.dumps(manifest).encode()
+    trailer = (
+        manifest_json
+        + struct.pack("<I", len(manifest_json))
+        + struct.pack("<H", 1)
+        + b"made with fw2tar"
+    )
     with open(tmp_path, "ab") as f, gzip.GzipFile(fileobj=f, mode="wb") as g:
-        g.write(b"\x00" * 0x10)
-        g.write(json.dumps(metadata).encode())
-        g.write(b"\nmade with fw2tar")
+        g.write(trailer)
 
     tmp_path.rename(out_path)
 


### PR DESCRIPTION
## Why

fw2tar's output must stay a **single, consistently-extractable tar**, but consumers (Penguin, and others) need *side-channel information* that doesn't belong in the rootfs payload. The first instance is the char/block **device nodes** fw2tar strips: Penguin deliberately doesn't want raw nodes in the rehosted fs (it recreates them with `mknod` post-extraction), but today the knowledge of *what was there* is lost (#53).

There was already a "tacked-on spec" — after the tar EOF blocks, fw2tar appended a JSON blob + a `made with fw2tar` magic — but it was **un-versioned, fragilely framed, and self-inconsistent** across its three touchpoints. In particular `utils/show_metadata.py`'s null-scan + `split('\n')` only worked on `stitch` output and `ValueError`'d on real fw2tar archives.

## What

Turn that trailer into a **versioned, robustly-framed manifest**. The tar payload stays plain; everything beyond it lives in the manifest:

\`\`\`json
{ "version": 1, "file": "...", "input_hash": "...", "fw2tar_command": [...],
  "extractor": "unblob", "devices": [{"path","kind","major","minor","mode"}] }
\`\`\`

**Framing** (decompressed gzip tail, written last): `JSON · u32 len · u16 frame-version · 16-byte "made with fw2tar"` magic. Self-locating from the end, version-tolerant, works whether the trailer is in the same gzip member (fw2tar) or a concatenated one (stitch). Future `mounts` / `secondary_filesystems` are additive — readers ignore unknown keys, so no version bump needed.

**Emission**: the manifest is embedded in the gzip trailer **and** always written as `<archive>.manifest.json`. The device-strip is now non-lossy and always warned; `--log-devices` is removed (redundant). All three touchpoints (`src/archive.rs`, `utils/stitch/plan.py`, `utils/show_metadata.py`) now agree, fixing the latent reader bug.

## Scope

Device nodes now; the envelope reserves room for **mounts / secondary filesystems** (documented, version-stable) but doesn't populate them. The **Penguin-side reader** is a separate follow-up — this PR is fw2tar-only.

## Verification

- \`cargo test\` (16, incl. new trailer round-trip + device serialization), \`cargo fmt\`, clippy clean (remaining warnings are all pre-existing, in untouched files).
- Real fw2tar run on TL-WR841N → correct \`version:1\` sidecar with \`extractor\`/\`devices\`.
- \`show_metadata.py\` now parses the **real embedded trailer** (it couldn't before).
- Stitch-framed trailer (separate gzip member) parses correctly.
- No baseline/output-set impact: \`tar_to_json.py\` reads only payload members; test globs are \`*.rootfs.tar.gz\`-specific.

> Note: the 89-node TL-WR841N device-populated manifest is exercised by the fakeroot container/nightly path (host runs produce \`devices: []\` because without fakeroot the extractors can't materialize device nodes). The capture logic in \`tar_fs\` is unchanged from the prior verified implementation; only its destination changed.