### PR TITLE
behavior: pin exact mismatch counts in the permission matrix gate

### DIFF
--- a/tests/BEHAVIOR.md
+++ b/tests/BEHAVIOR.md
@@ -70,7 +70,7 @@ extractor**. This is the gated matrix (`run_in_container.sh`):
 ```
 fixture    unblob       binwalk      binwalkv3
 squashfs   ok           ok           ok
-cramfs     ok           ok           none
+cramfs     ok           ok           diff:6
 ubifs      ok           ok           none
 jffs2      diff:3       diff:3       diff:3
 ext2       diff:4       none         none
@@ -80,19 +80,21 @@ romfs      none         none         diff:23
 yaffs      skip         skip         skip
 iso9660    diff:6       diff:6       none
 fat        none         none         none
-cpio       diff:1       ok           none
+cpio       diff:1       ok           diff:6
 tar        ok           ok           ok
-zip        diff:4       diff:4       diff:4
+zip        diff:6       diff:4       diff:6
 ```
 
 `ok` = full fidelity · `diff:N` = rootfs produced but N metadata mismatches ·
 `none` = no rootfs produced · `skip` = fixture image not built (no builder).
+Each `diff:N` count is **pinned** by the gate (see "Gate", below).
 
 ### Cross-extractor findings
 
 - **squashfs** is the only type all three extractors handle perfectly.
-- **cramfs and ubifs**: full fidelity under unblob *and* binwalk, but **binwalkv3
-  doesn't extract them at all** (`none`).
+- **cramfs and ubifs**: full fidelity under unblob *and* binwalk. binwalkv3 now
+  extracts cramfs but loses metadata (`diff:6`), and still doesn't extract ubifs
+  at all (`none`).
 - **ext2/3/4**: **only unblob** produces a rootfs (and it drops special bits);
   binwalk/binwalkv3 produce nothing detectable.
 - **romfs**: the mirror image — **only binwalkv3** produces a rootfs (with heavy perm
@@ -179,14 +181,16 @@ across all types.
 
 ## Testing model
 
-The harness records an outcome **category** for every `fixture × extractor` cell and
-gates it against the `EXPECT` table in `run_in_container.sh`:
+The harness records an outcome for every `fixture × extractor` cell and gates it
+against the `EXPECT` table in `run_in_container.sh`:
 
 - `ok` — rootfs produced, every entry matches (full fidelity). A cell that drops from
   `ok` is a real regression.
-- `diff` — rootfs produced but some metadata lost (a current bug). When a fix lands the
-  cell flips `diff → ok`; the gate then fails until you update `EXPECT`, which is the
-  signal to record the win.
+- `diff:N` — rootfs produced but N metadata properties lost (a current bug). The count
+  is **pinned exactly**: both worsening a bug (`diff:3 → diff:5`) and partially fixing
+  one (`diff:3 → diff:1`) fail the gate, as does a full fix (`diff → ok`). Any of these
+  is the signal to update `EXPECT` — either re-baselining the count or promoting the
+  cell to `ok`.
 - `none` — no rootfs produced (extractor can't handle the type, or loses so much that
   detection fails). A cell moving `none → diff/ok` means new coverage — update `EXPECT`.
 - `skip` — fixture image couldn't be built (left ungated).

--- a/tests/behavior/run_in_container.sh
+++ b/tests/behavior/run_in_container.sh
@@ -38,31 +38,34 @@ FIXTURES=(
     "zip|rootfs.zip"
 )
 
-# Expected outcome category per "<fixture>/<extractor>" cell:
-#   ok    rootfs produced, every entry matches expectations (full fidelity)
-#   diff  rootfs produced but some metadata lost (a known bug)
-#   none  no rootfs produced (extractor can't / metadata lost so it isn't detected)
-#   skip  fixture image could not be built (e.g. yaffs without mkyaffs2image)
+# Expected outcome per "<fixture>/<extractor>" cell:
+#   ok      rootfs produced, every entry matches expectations (full fidelity)
+#   diff:N  rootfs produced but N metadata properties lost (a known bug); the
+#           count is PINNED — both worsening (N grows) and partially fixing it
+#           (N shrinks) trip the gate, so a real fork fix forces a re-baseline
+#           or a promotion to `ok`
+#   none    no rootfs produced (extractor can't / metadata lost so it isn't detected)
+#   skip    fixture image could not be built (e.g. yaffs without mkyaffs2image)
 # Cells with no entry are reported but NOT gated (yaffs is left ungated because its
 # image only builds when mkyaffs2image is present). Captured 2026-06-22 against the
 # Docker image; re-baselined for the Nix image (binwalk v3.1.0 from nixpkgs now
-# extracts cramfs/cpio where the older build produced no rootfs). 2026-06-23: the
-# full matrix (nightly-only) showed unblob/binwalk now extract an iso9660 rootfs
-# (diff: iso9660/Rock Ridge drops suid/sgid/sticky bits and some symlinks); was none.
+# extracts cramfs/cpio where the older build produced no rootfs). 2026-06-23:
+# unblob/binwalk now extract an iso9660 rootfs (Rock Ridge drops suid/sgid/sticky
+# + some symlinks); pinned exact mismatch counts for every known-bug cell.
 declare -A EXPECT=(
     [squashfs/unblob]=ok    [squashfs/binwalk]=ok    [squashfs/binwalkv3]=ok
-    [cramfs/unblob]=ok      [cramfs/binwalk]=ok      [cramfs/binwalkv3]=diff
+    [cramfs/unblob]=ok      [cramfs/binwalk]=ok      [cramfs/binwalkv3]=diff:6
     [ubifs/unblob]=ok       [ubifs/binwalk]=ok       [ubifs/binwalkv3]=none
-    [jffs2/unblob]=diff     [jffs2/binwalk]=diff     [jffs2/binwalkv3]=diff
-    [ext2/unblob]=diff      [ext2/binwalk]=none      [ext2/binwalkv3]=none
-    [ext3/unblob]=diff      [ext3/binwalk]=none      [ext3/binwalkv3]=none
-    [ext4/unblob]=diff      [ext4/binwalk]=none      [ext4/binwalkv3]=none
-    [romfs/unblob]=none     [romfs/binwalk]=none     [romfs/binwalkv3]=diff
-    [iso9660/unblob]=diff   [iso9660/binwalk]=diff   [iso9660/binwalkv3]=none
+    [jffs2/unblob]=diff:3   [jffs2/binwalk]=diff:3   [jffs2/binwalkv3]=diff:3
+    [ext2/unblob]=diff:4    [ext2/binwalk]=none      [ext2/binwalkv3]=none
+    [ext3/unblob]=diff:4    [ext3/binwalk]=none      [ext3/binwalkv3]=none
+    [ext4/unblob]=diff:4    [ext4/binwalk]=none      [ext4/binwalkv3]=none
+    [romfs/unblob]=none     [romfs/binwalk]=none     [romfs/binwalkv3]=diff:23
+    [iso9660/unblob]=diff:6 [iso9660/binwalk]=diff:6 [iso9660/binwalkv3]=none
     [fat/unblob]=none       [fat/binwalk]=none       [fat/binwalkv3]=none
-    [cpio/unblob]=diff      [cpio/binwalk]=ok        [cpio/binwalkv3]=diff
+    [cpio/unblob]=diff:1    [cpio/binwalk]=ok        [cpio/binwalkv3]=diff:6
     [tar/unblob]=ok         [tar/binwalk]=ok         [tar/binwalkv3]=ok
-    [zip/unblob]=diff       [zip/binwalk]=diff       [zip/binwalkv3]=diff
+    [zip/unblob]=diff:6     [zip/binwalk]=diff:4     [zip/binwalkv3]=diff:6
 )
 
 # Optional fixture subset (positional args). Empty => all fixtures.
@@ -151,12 +154,20 @@ echo
 echo "legend: ok=full fidelity  diff:N=rootfs with N metadata mismatches  none=no rootfs  skip=image not built"
 
 # ---- gate against EXPECT (only fixtures that were run) ----
+# Cells expected as a known bug pin the EXACT mismatch count (diff:N): both
+# worsening a bug (diff:3 -> diff:5) and partially fixing one (diff:3 -> diff:1)
+# trip the gate, forcing a re-baseline or a fixture promotion to golden. Cells
+# expected ok/none/skip are matched by category (the count is irrelevant there).
 category() { case "$1" in diff:*) echo diff ;; *) echo "$1" ;; esac; }
 failures=0
 for key in "${!EXPECT[@]}"; do
     want_fixture "${key%%/*}" || continue
     want="${EXPECT[$key]}"
-    got="$(category "${CELL[$key]:-MISSING}")"
+    raw="${CELL[$key]:-MISSING}"
+    case "$want" in
+        diff:*) got="$raw" ;;                  # exact mismatch count required
+        *)      got="$(category "$raw")" ;;    # ok / none / skip: category only
+    esac
     if [ "$got" != "$want" ]; then
         echo -e "${RED}REGRESSION $key: expected $want, got ${CELL[$key]:-MISSING}${END}"
         failures=$((failures+1))


### PR DESCRIPTION
## Why

The permission-fidelity characterization matrix (#56) gated only on outcome **category** (`ok`/`diff`/`none`/`skip`), collapsing `diff:N` → `diff`. That meant:

- a known bug could **silently worsen** (`diff:3` → `diff:5`) and still pass;
- a **partial fix** (`diff:3` → `diff:1`) wouldn't be noticed;
- the upcoming fork permission fixes (#52 / #54 / #55) had nothing precise to validate against or lock in.

## What

Gate known-bug cells on the **exact count**: a cell expected `diff:N` must report exactly `diff:N`; `ok`/`none`/`skip` still match by category (count is irrelevant there). Any change — worsening, partial fix, or full fix to `ok` — now fails the gate and forces an `EXPECT` re-baseline or a promotion to golden.

Re-measured every cell against the **current Nix test image** and pinned the counts. Notable updates vs the prior (category-only) baseline:

| cell | was | now |
|---|---|---|
| cramfs/binwalkv3 | `diff` | `diff:6` |
| cpio/binwalkv3 | `diff`/`none` | `diff:6` |
| zip/unblob | `diff` | `diff:6` |
| zip/binwalkv3 | `diff` | `diff:6` |
| iso9660/unblob, iso9660/binwalk | `diff` | `diff:6` |

`BEHAVIOR.md`'s matrix and "Testing model" section updated to match.

## Verification

- Full matrix (`./tests/behavior/run.sh`) on the freshly-built `.#testImage`: **green** with the pinned counts.
- Gate logic unit-checked: `diff:3`→`diff:5` (worsen), `diff:3`→`diff:1` (partial), `diff:3`→`ok` (full fix), and `none`→`diff:6` (new coverage) all correctly fail; exact matches pass.
- No code change — test-harness + docs only. Per-PR `build.yaml` runs the subset; `nightly.yaml` runs the full matrix.