### PR TITLE
Expose extractionBundle output for downstream co-located extraction

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -259,6 +259,27 @@
             extraCommands = imageExtraCommands;
             config = imageConfig;
           };
+          # The complete firmware-extraction toolset as one symlinked env, for
+          # downstream flakes (e.g. penguin) that co-locate extraction in their
+          # own image rather than shelling out to the fw2tar container. Same
+          # components as the image's runtime contents, minus the container-UX
+          # entry points (banner/install scripts).
+          extractionBundle = pkgs.buildEnv {
+            name = "fw2tar-extraction-bundle";
+            # unblob's runtimeDeps and extractionTools both carry cramfsprogs (at
+            # slightly different revs); the image tolerates this via dockerTools
+            # layering, so mirror that here rather than failing the env.
+            ignoreCollisions = true;
+            paths = [
+              fw2tar
+              fakerootFw2tar
+              fwstitch
+              unblobPkg
+              binwalkV3
+              pythonEnv
+              pkgs.fakeroot
+            ] ++ extractionTools;
+          };
         in
         {
           inherit
@@ -266,6 +287,7 @@
             binwalk2
             dockerImage
             testImage
+            extractionBundle
             ;
           default = fw2tar;
         }


### PR DESCRIPTION
Adds a single new package output, `extractionBundle` — a `buildEnv` of the complete firmware-extraction toolset already assembled for the fw2tar image (fw2tar, fakeroot_fw2tar, fwstitch, unblob, binwalk v3, the binwalk2 python env, fakeroot, and the `extractionTools` closure).

## Why
The penguin nixification (rehosting/penguin#868) keeps the firmware-extraction stack **co-located** in the penguin image. Rather than re-deriving fw2tar/unblob/binwalk/the extractor backends, penguin consumes this bundle as a cross-flake input — one authoritative source for the extraction toolchain.

## Notes
- Purely additive; no existing output changes.
- `ignoreCollisions = true` mirrors the image's dockerTools layering (unblob's runtimeDeps and `extractionTools` both carry `cramfsprogs` at slightly different revs).
- Verified: `nix build .#extractionBundle` produces 254 bins; fw2tar/fakeroot_fw2tar/binwalk/unblob/fwstitch/jefferson/sasquatch/7zz/unsquashfs/cpio all present.