### PR TITLE
Concise run progress, stray-artifact cleanup, and error-path debts (#23)

### DIFF
--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -41,6 +41,12 @@ pub enum ExtractProcessError {
 
     #[error("Failed to find any filesystems in the extracted contents")]
     FailToFind,
+
+    #[error("Failed to write tar archive ({0})")]
+    TarFail(io::Error),
+
+    #[error("Failed to hash tar archive ({0})")]
+    HashFail(io::Error),
 }
 
 pub fn extract_and_process(
@@ -50,7 +56,6 @@ pub fn extract_and_process(
     scratch_dir: Option<&Path>,
     verbose: bool,
     primary_limit: usize,
-    _secondary_limit: usize,
     results: &Mutex<Vec<ExtractionResult>>,
     metadata: &Metadata,
 ) -> Result<(), ExtractProcessError> {
@@ -66,11 +71,7 @@ pub fn extract_and_process(
 
     let extract_dir = temp_dir.path();
 
-    let log_file = {
-        // Simple string append to avoid with_extension() being greedy
-        let file_name = out_file_base.file_name().unwrap().to_string_lossy();
-        out_file_base.with_file_name(format!("{}.{extractor_name}.log", file_name))
-    };
+    let log_file = extractor_log_path(out_file_base, extractor_name);
 
     let start_time = Instant::now();
 
@@ -79,25 +80,26 @@ pub fn extract_and_process(
         .map_err(ExtractProcessError::ExtractFail)?;
 
     let elapsed = start_time.elapsed().as_secs_f32();
-
-    if verbose {
-        println!("{extractor_name} took {elapsed:.2} seconds")
-    } else {
-        log::info!("{extractor_name} took {elapsed:.2} seconds");
-    }
+    log::info!("{extractor_name} took {elapsed:.2} seconds");
 
     let rootfs_choices = find_linux_filesystems(extract_dir, None, extractor_name);
 
     if rootfs_choices.is_empty() {
+        eprintln!("fw2tar:   {extractor_name} finished in {elapsed:.1}s — no Linux filesystem found");
         log::error!("No Linux filesystems found extracting {in_file:?} with {extractor_name}");
         return Err(ExtractProcessError::FailToFind);
     }
 
+    eprintln!(
+        "fw2tar:   {extractor_name} finished in {elapsed:.1}s — found {n} candidate filesystem(s)",
+        n = rootfs_choices.len()
+    );
+
     for (i, fs) in rootfs_choices.iter().enumerate() {
         if i >= primary_limit {
-            println!(
-                "WARNING: skipping {n} filesystems, if files are missing you may need to set --primary-limit higher",
-                n=rootfs_choices.len() - primary_limit
+            eprintln!(
+                "fw2tar:   {extractor_name}: skipping {n} more filesystem(s); raise --primary-limit if files are missing",
+                n = rootfs_choices.len() - primary_limit
             );
             break;
         }
@@ -108,10 +110,9 @@ pub fn extract_and_process(
             out_file_base.with_file_name(format!("{}.{extractor_name}.{i}.tar.gz", file_name))
         };
 
-        // XXX: improve error handling here
-        let (file_node_count, manifest) =
-            tar_fs(&fs.path, &tar_path, metadata, extractor_name).unwrap();
-        let archive_hash = sha1_file(&tar_path).unwrap();
+        let (file_node_count, manifest) = tar_fs(&fs.path, &tar_path, metadata, extractor_name)
+            .map_err(ExtractProcessError::TarFail)?;
+        let archive_hash = sha1_file(&tar_path).map_err(ExtractProcessError::HashFail)?;
 
         results.lock().unwrap().push(ExtractionResult {
             extractor: extractor_name,
@@ -131,6 +132,15 @@ pub fn extract_and_process(
     Ok(())
 }
 
+/// Per-extractor log file path next to the output base: `<base>.<extractor>.log`.
+/// Uses `with_file_name` (string append) rather than `with_extension`, which
+/// would greedily strip a dotted segment from the base. Shared by the producer
+/// (extraction) and the post-run stray-artifact cleanup so the two never drift.
+pub fn extractor_log_path(out_file_base: &Path, extractor_name: &str) -> PathBuf {
+    let file_name = out_file_base.file_name().unwrap().to_string_lossy();
+    out_file_base.with_file_name(format!("{file_name}.{extractor_name}.log"))
+}
+
 pub fn sha1_file(file: &Path) -> io::Result<String> {
     let bytes = std::fs::read(file)?;
 
@@ -139,4 +149,27 @@ pub fn sha1_file(file: &Path) -> io::Result<String> {
     let result = hasher.finalize();
 
     Ok(format!("{result:x}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extractor_log_path_appends_without_greedy_strip() {
+        // A dotted version segment in the base must survive (same contract as
+        // the output archive path).
+        assert_eq!(
+            extractor_log_path(Path::new("/out/RAX54Sv2-V1.1.4.28"), "unblob"),
+            PathBuf::from("/out/RAX54Sv2-V1.1.4.28.unblob.log")
+        );
+    }
+
+    #[test]
+    fn extractor_log_path_preserves_directory() {
+        assert_eq!(
+            extractor_log_path(Path::new("/out/dir/firmware"), "binwalkv3"),
+            PathBuf::from("/out/dir/firmware.binwalkv3.log")
+        );
+    }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -23,17 +23,9 @@ pub struct Args {
     #[arg(long)]
     pub loud: bool,
 
-    /// Create a file next to the output file reporting the extractor used
-    #[arg(long, alias("report_extractor"))]
-    pub report_extractor: bool,
-
     /// Maximum number of root-like filesystems to extract.
     #[arg(long, default_value_t = 1, alias("primary_limit"))]
     pub primary_limit: usize,
-
-    /// Maximum number of non-root-like filesystems to extract.
-    #[arg(long, default_value_t = 0, alias("secondary_limit"))]
-    pub secondary_limit: usize,
 
     /// Overwrite existing output file
     #[arg(long)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::PathBuf;
 
 use thiserror::Error;
@@ -15,4 +16,7 @@ pub enum Fw2tarError {
 
     #[error("Output file ({0:?}) already exists. Use --force to overwrite.")]
     OutputExists(PathBuf),
+
+    #[error("Failed to write output archive ({0:?}): {1}")]
+    OutputWrite(PathBuf, io::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod error;
 pub mod extractors;
 pub mod metadata;
 
-use analysis::{extract_and_process, ExtractionResult};
+use analysis::{extract_and_process, extractor_log_path, ExtractionResult};
 pub use error::Fw2tarError;
 use metadata::{Manifest, Metadata};
 
@@ -17,7 +17,6 @@ use std::{env, fs, thread};
 pub enum BestExtractor {
     Best(&'static str),
     Only(&'static str),
-    Identical(&'static str),
     None,
 }
 
@@ -67,7 +66,7 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
 
     extractors::set_timeout(args.timeout);
 
-    let extractors: Vec<_> = args
+    let extractors: Vec<String> = args
         .extractors
         .map(|extractors| extractors.split(",").map(String::from).collect())
         .unwrap_or_else(|| {
@@ -76,11 +75,18 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
                 .collect()
         });
 
+    eprintln!(
+        "fw2tar: extracting {} with {} extractor(s): {}",
+        args.firmware.display(),
+        extractors.len(),
+        extractors.join(", ")
+    );
+
     let results: Mutex<Vec<ExtractionResult>> = Mutex::new(Vec::new());
 
     thread::scope(|threads| -> Result<(), Fw2tarError> {
-        for extractor_name in extractors {
-            let extractor = extractors::get_extractor(&extractor_name)
+        for extractor_name in &extractors {
+            let extractor = extractors::get_extractor(extractor_name)
                 .ok_or_else(|| Fw2tarError::InvalidExtractor(extractor_name.clone()))?;
 
             threads.spawn(|| {
@@ -91,7 +97,6 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
                     args.scratch_dir.as_deref(),
                     args.loud,
                     args.primary_limit,
-                    args.secondary_limit,
                     &results,
                     &metadata,
                 ) {
@@ -106,35 +111,73 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
     let results = results.lock().unwrap();
     let mut best_results: Vec<_> = results.iter().filter(|&res| res.index == 0).collect();
 
-    let result = if best_results.is_empty() {
+    if best_results.is_empty() {
         return Ok((BestExtractor::None, selected_output_path));
-    } else if best_results.len() == 1 {
-        Ok((
-            BestExtractor::Only(best_results[0].extractor),
-            selected_output_path.clone(),
-        ))
-    } else {
-        best_results.sort_by_key(|res| Reverse((res.file_node_count, res.extractor == "unblob")));
+    }
 
-        Ok((
-            BestExtractor::Best(best_results[0].extractor),
-            selected_output_path.clone(),
-        ))
+    let result = if best_results.len() == 1 {
+        BestExtractor::Only(best_results[0].extractor)
+    } else {
+        eprintln!(
+            "fw2tar: comparing {} candidate archives to pick the best extraction",
+            best_results.len()
+        );
+        best_results.sort_by_key(|res| Reverse((res.file_node_count, res.extractor == "unblob")));
+        BestExtractor::Best(best_results[0].extractor)
     };
 
     let best_result = best_results[0];
 
-    fs::rename(&best_result.path, &selected_output_path).unwrap();
+    fs::rename(&best_result.path, &selected_output_path)
+        .map_err(|e| Fw2tarError::OutputWrite(selected_output_path.clone(), e))?;
 
     write_manifest_sidecar(&best_result.manifest, &selected_output_path);
 
-    result
+    // The winning archive was renamed to `selected_output_path`; everything else
+    // produced during the run (losing candidate tarballs, per-extractor logs) is
+    // intermediate scratch the user did not ask for. Sweep it up on success.
+    cleanup_stray_artifacts(&results, &extractors, &output, args.loud);
+
+    Ok((result, selected_output_path))
+}
+
+/// Remove intermediate files left next to the output after a successful run:
+/// the non-selected candidate `*.tar.gz` archives (the winner has already been
+/// renamed away from its candidate path) and, unless running `--loud`, the
+/// per-extractor `*.log` files. Best-effort: failures are logged, never fatal.
+fn cleanup_stray_artifacts(
+    results: &[ExtractionResult],
+    requested_extractors: &[String],
+    output_base: &Path,
+    loud: bool,
+) {
+    for res in results {
+        if res.path.exists() {
+            if let Err(e) = fs::remove_file(&res.path) {
+                log::warn!("failed to remove intermediate archive {:?}: {e}", res.path);
+            }
+        }
+    }
+
+    if loud {
+        return;
+    }
+
+    for extractor in requested_extractors {
+        let log_path = extractor_log_path(output_base, extractor);
+        if log_path.exists() {
+            if let Err(e) = fs::remove_file(&log_path) {
+                log::warn!("failed to remove extractor log {log_path:?}: {e}");
+            }
+        }
+    }
 }
 
 /// Write the chosen archive's manifest as a standalone `<archive>.manifest.json`
-/// sidecar (the same content embedded in the archive's gzip trailer), and warn
-/// about any device nodes that were stripped so the loss is never silent. The
-/// sidecar is best-effort: a failure to write it is logged, not fatal.
+/// sidecar (the same content embedded in the archive's gzip trailer), and report
+/// any device nodes that were stripped so the loss is never silent. The progress
+/// notices go to stderr (always visible, unlike the level-gated logger); the
+/// sidecar itself is best-effort — a failure to write it is logged, not fatal.
 fn write_manifest_sidecar(manifest: &Manifest, output: &Path) {
     if !manifest.devices.is_empty() {
         let in_dev = manifest
@@ -142,10 +185,9 @@ fn write_manifest_sidecar(manifest: &Manifest, output: &Path) {
             .iter()
             .filter(|d| d.path.starts_with("/dev/"))
             .count();
-        log::warn!(
-            "stripped {} device node(s) from the rootfs ({in_dev} under /dev) — see {}.manifest.json",
+        eprintln!(
+            "fw2tar: stripped {} device node(s) from the rootfs ({in_dev} under /dev) — recorded in the manifest",
             manifest.devices.len(),
-            output.display()
         );
     }
 
@@ -156,7 +198,7 @@ fn write_manifest_sidecar(manifest: &Manifest, output: &Path) {
     };
     match serde_json::to_vec_pretty(manifest) {
         Ok(bytes) => match fs::write(&sidecar_path, bytes) {
-            Ok(()) => log::info!("wrote manifest sidecar {sidecar_path:?}"),
+            Ok(()) => eprintln!("fw2tar: wrote manifest sidecar {}", sidecar_path.display()),
             Err(e) => log::warn!("failed to write manifest sidecar {sidecar_path:?}: {e}"),
         },
         Err(e) => log::warn!("failed to serialize manifest: {e}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,6 @@ fn main() {
             BestExtractor::Only(extractor) => {
                 println!("Only extractor: {extractor}, archive at {output_path:?}");
             }
-            BestExtractor::Identical(extractor) => {
-                println!("Extractors Identical, using {extractor}. Archive at {output_path:?}");
-            }
             BestExtractor::None => {
                 println!("No extractor succeeded.");
                 exit(2);


### PR DESCRIPTION
Closes #23.

`fw2tar` used to be silent from launch until the final result line — often
minutes — and left every per-extractor log plus the losing candidate tarballs
strewn next to the output. It also carried a few never-exercised code paths.

## Run progress (#23)
Concise, always-on progress to **stderr**, so **stdout stays just the final
result line** and callers can keep scripting against it:

```
fw2tar: extracting fw.squashfs with 3 extractor(s): binwalk, binwalkv3, unblob
fw2tar:   binwalkv3 finished in 0.0s — found 1 candidate filesystem(s)
fw2tar:   binwalk finished in 0.9s — found 1 candidate filesystem(s)
fw2tar:   unblob finished in 2.3s — found 1 candidate filesystem(s)
fw2tar: comparing 3 candidate archives to pick the best extraction
Best extractor: unblob, archive at "fw.rootfs.tar.gz"      <- stdout
```

The stripped-device-node and manifest-sidecar notices also move from the
level-gated logger (hidden unless `FW2TAR_LOG` is set) to always-on stderr.

## Stray-artifact cleanup
On a successful run, remove the non-selected candidate `*.tar.gz` archives and
— unless `--loud` — the per-extractor `*.log` files. The output directory now
holds only `<name>.rootfs.tar.gz` and its `.manifest.json`:

```
before:  fw.rootfs.tar.gz  fw.rootfs.tar.gz.manifest.json
         fw.binwalk.0.tar.gz  fw.binwalkv3.0.tar.gz
         fw.binwalk.log  fw.binwalkv3.log  fw.unblob.log
after:   fw.rootfs.tar.gz  fw.rootfs.tar.gz.manifest.json
```

The log-path format is centralized in `analysis::extractor_log_path` so the
producer and the cleanup can never drift.

## Code debts
- Propagate errors instead of `.unwrap()` on the output rename
  (`Fw2tarError::OutputWrite`) and on `tar_fs`/`sha1_file`
  (`ExtractProcessError::TarFail`/`HashFail`) — a write/extract failure now
  surfaces a message instead of a panic.
- Drop the dead `--report-extractor` flag, the unused `--secondary-limit` /
  `_secondary_limit` parameter, and the never-constructed
  `BestExtractor::Identical` variant.

## Validation
- `cargo test --locked` (18 tests, +2 for `extractor_log_path`).
- Behavior harness (`tests/behavior`) on squashfs + cpio: matrix unchanged.
- Manual all-extractor run in `.#testImage`: progress lines render, stdout
  stays clean under `2>/dev/null`, losers + logs are swept on a normal run, and
  `--loud` retains the logs.
