### PR TITLE
Shrink downstream closure: slim openai, drop fwstitch from bundle, share nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,22 +63,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "binwalk-v2": "binwalk-v2",
@@ -105,7 +89,9 @@
       "inputs": {
         "filter": "filter",
         "flake-compat": "flake-compat",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "shell-hooks": "shell-hooks"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,14 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     # The rehosting forks. Pinned by flake.lock to exact revisions.
-    unblob.url = "github:rehosting/unblob";
+    # unblob follows our nixpkgs so the whole extraction stack (fw2tar + unblob
+    # + binwalk) resolves to a single CPython/glibc, and so do downstream
+    # consumers that make `fw2tar` follow theirs (e.g. penguin). Without this,
+    # unblob drags in a second nixpkgs and a duplicate interpreter.
+    unblob = {
+      url = "github:rehosting/unblob";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     binwalk-v2 = {
       url = "github:rehosting/binwalk";
@@ -69,8 +76,31 @@
           # needs openai/pydantic/pyyaml (utils/stitch/requirements.txt), which
           # don't build on 3.11 (a doc dep needs >=3.12), so use the default
           # python3 here rather than binwalk's pinned 3.11.
+          #
+          # nixpkgs' `openai` propagates its optional `datalib`/`realtime`/
+          # `voice-helpers` extras unconditionally, dragging in numpy + blas +
+          # lapack + sounddevice + aiohttp + websockets (~325 MB once the second
+          # interpreter is counted). fwstitch only uses the plain chat-completions
+          # HTTP client, so strip those extras -- they are `Requires-Dist`
+          # extras, not core deps, so the runtime metadata check stays happy.
+          slimOpenai =
+            let
+              heavy = [
+                "numpy"
+                "sounddevice"
+                "aiohttp"
+                "httpx-aiohttp"
+                "websockets"
+                "pandas"
+              ];
+              keep = p: !(builtins.elem (p.pname or "") heavy);
+            in
+            pkgs.python3.pkgs.openai.overridePythonAttrs (old: {
+              dependencies = builtins.filter keep (old.dependencies or [ ]);
+              propagatedBuildInputs = builtins.filter keep (old.propagatedBuildInputs or [ ]);
+            });
           stitchEnv = pkgs.python3.withPackages (ps: [
-            ps.openai
+            slimOpenai
             ps.pydantic
             ps.pyyaml
           ]);
@@ -264,6 +294,13 @@
           # own image rather than shelling out to the fw2tar container. Same
           # components as the image's runtime contents, minus the container-UX
           # entry points (banner/install scripts).
+          #
+          # `fwstitch` (the LLM-driven multi-fs stitcher) is intentionally NOT in
+          # the bundle: it is a standalone fw2tar-container tool, not part of the
+          # penguin rehost runtime, and it drags in its own openai env + a second
+          # CPython interpreter. Keeping it out of the bundle keeps that closure
+          # out of downstream images (penguin). It stays in the fw2tar container
+          # via imageContents above.
           extractionBundle = pkgs.buildEnv {
             name = "fw2tar-extraction-bundle";
             # unblob's runtimeDeps and extractionTools both carry cramfsprogs (at
@@ -273,7 +310,6 @@
             paths = [
               fw2tar
               fakerootFw2tar
-              fwstitch
               unblobPkg
               binwalkV3
               pythonEnv


### PR DESCRIPTION
## What

Three closure-size fixes to fw2tar, all surfaced while shrinking the penguin image (which co-locates fw2tar's `extractionBundle`).

### 1. Slim `openai` in `stitchEnv`
nixpkgs' `openai` unconditionally propagates its `voice-helpers`/`realtime`/`datalib` extras — pulling in **numpy + blas + lapack + sounddevice** (~190 MB). `fwstitch` only uses the chat-completions HTTP client, so we override `openai` to drop those.

### 2. Drop `fwstitch` from `extractionBundle`
`fwstitch` (LLM-driven multi-fs stitcher) is a standalone fw2tar-container tool, not part of a downstream rehost runtime. It stays in the container (`imageContents`), but leaving it in the bundle dragged its openai env **and a second CPython interpreter** into every consumer. Removing it from the bundle keeps that out of penguin.

### 3. `unblob` follows our nixpkgs
fw2tar, unblob, and binwalk each pinned a different nixpkgs → **three CPython 3.13 builds + three glibc**. Making unblob follow fw2tar's nixpkgs (and consumers making fw2tar follow theirs) collapses these to one.

## Impact (measured in the penguin image, which consumes the bundle)
- 4 CPython interpreters → 2 (one shared 3.13 + binwalk's pinned 3.11)
- 3 glibc → 1
- **penguin image: 5.97 GB → 5.41 GB uncompressed, 2.21 GB → 1.99 GB compressed**

## Verification
- `openai` still imports in `stitchEnv`; `fwstitch` still runs in the fw2tar container
- `unblob`, `binwalk` v3, `fw2tar`, and `binwalk` v2 (on its 3.11 env) all build and run on the shared nixpkgs
- fw2tar container still ships `fwstitch`