### PR TITLE
Bump unblob: cramfs permission restore on opposite-endian images

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -95,11 +95,11 @@
         "shell-hooks": "shell-hooks"
       },
       "locked": {
-        "lastModified": 1782616184,
-        "narHash": "sha256-QXwSjNww3U8qIoNtNs11mf294Fm21Cf57dHbpXZ+9L0=",
+        "lastModified": 1782620433,
+        "narHash": "sha256-okHkkQRIeqcv6zfIb+eaYMi3/tstK1iui3JLRe3BbAo=",
         "owner": "rehosting",
         "repo": "unblob",
-        "rev": "7176e0ab4076130de47c55e958413a42eb3632c5",
+        "rev": "f52d9c0ce4a19608c2f41146b66a5f748a5f0bd1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Final piece of the ext/cramfs fidelity train. #66 bumped the lock to unblob `7176e0ab` (#8 ext perms + #9 cramfs BE data recovery) but landed before rehosting/unblob#10. This bumps the lock to unblob `f52d9c0c` to pick that up.

**rehosting/unblob#10** makes the opposite-endian cramfs path (the `7z` fallback from #9) re-apply the real modes parsed straight from the cramfs inodes — `7z` had been collapsing directories to `0700` and dropping setuid/setgid/sticky bits. So big-endian (MIPS/PPC) firmware cramfs analyzed on an x86 host now keeps correct permissions, matching the native-endian `cramfsck` path.

**Scope:** lock-only. The behavior harness builds host-endian cramfs only, so the matrix is unaffected and no gate cells change. Validated with `nix build .#testImage` (overlay resolves under fw2tar's newer nixpkgs). unblob's own suite is green at f52d9c0c (`nix build .#unblob` = 1086 passed).