### PR TITLE
behavior: nested fixtures + no-cruft/recursion-cruft gates (fixes binwalk v3 .extracted leak)

### DIFF
--- a/src/analysis/directory_executables.rs
+++ b/src/analysis/directory_executables.rs
@@ -2,17 +2,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use walkdir::{DirEntry, WalkDir};
 
-const EXECUTABLE_MASK: u32 = libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH;
+use crate::archive::is_extraction_artifact;
 
-static BAD_SUFFIXES: &[&str] = &[
-    "_extract",
-    ".extracted", // binwalk v3 names its in-place recursion dirs `<name>.extracted`
-    ".uncompressed",
-    ".unknown",
-    "cpio-root",
-    "squashfs-root",
-    "0.tar",
-];
+const EXECUTABLE_MASK: u32 = libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH;
 
 #[derive(Debug, Clone)]
 pub struct ExecutableInfo {
@@ -34,22 +26,8 @@ pub fn get_dir_executable_info(dir: &Path) -> ExecutableInfo {
         entry
             .path()
             .file_name()
-            .map(|name| {
-                name.to_str().map(|name| {
-                    for suffix in BAD_SUFFIXES {
-                        if name.ends_with(suffix) {
-                            return false;
-                        }
-                    }
-
-                    if name.starts_with("squashfs-root-") {
-                        return false;
-                    }
-
-                    true
-                })
-            })
-            .flatten()
+            .and_then(|name| name.to_str())
+            .map(|name| !is_extraction_artifact(name))
             .unwrap_or(true)
     };
 

--- a/src/analysis/directory_executables.rs
+++ b/src/analysis/directory_executables.rs
@@ -6,6 +6,7 @@ const EXECUTABLE_MASK: u32 = libc::S_IXUSR | libc::S_IXGRP | libc::S_IXOTH;
 
 static BAD_SUFFIXES: &[&str] = &[
     "_extract",
+    ".extracted", // binwalk v3 names its in-place recursion dirs `<name>.extracted`
     ".uncompressed",
     ".unknown",
     "cpio-root",

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -23,18 +23,34 @@ pub const MANIFEST_MAGIC: &[u8; 16] = b"made with fw2tar";
 /// Version of the trailer *framing* (distinct from the manifest schema version).
 const TRAILER_FRAME_VERSION: u16 = 1;
 
-static BAD_PREFIXES: &[&str] = &["0.tar", "squashfs-root"];
-// Extractor recursive-unpack directories created *in place* next to the file
-// they came from. unblob uses `<name>_extract`; binwalk v3 uses `<name>.extracted`
-// (and `decompressed.bin` chunks beneath it). These are not part of the firmware
-// and must never ride along into the output archive.
-static BAD_SUFFIXES: &[&str] = &["_extract", ".extracted", ".uncompressed", ".unknown"];
+// Names that an extractor gives to the recursive-unpack / carve directories it
+// creates *in place* next to the data it came from. These are scaffolding, not
+// firmware: they must be excluded both from the output archive (`tar_fs`) and
+// from rootfs detection (`directory_executables`). This is the single source of
+// truth for both — keeping them in one list is what stops the two from drifting
+// (a drift is exactly what let binwalk v3's `.extracted` dirs leak originally).
+//
+//   suffix `_extract`                  unblob      (`<name>_extract`)
+//   suffix `.extracted`                binwalk v3  (`<name>.extracted`; nested
+//                                                    `decompressed.bin`/`0` live
+//                                                    under it, pruned with it)
+//   suffix `.uncompressed`/`.unknown`  unblob carve chunks
+//   prefix `squashfs-root`             binwalk     (`squashfs-root`, `squashfs-root-0`)
+//   prefix `cpio-root`                 binwalk     (`cpio-root`)
+//   prefix `0.tar`                     binwalk     (`0.tar`, `0.tar.gz`)
+static ARTIFACT_PREFIXES: &[&str] = &["0.tar", "squashfs-root", "cpio-root"];
+static ARTIFACT_SUFFIXES: &[&str] = &["_extract", ".extracted", ".uncompressed", ".unknown"];
 
 /// True when a path component looks like an extractor artifact (an intermediate
-/// carve/unpack directory) that should be excluded from the output archive.
-fn is_extraction_artifact(name: &str) -> bool {
-    BAD_PREFIXES.iter().any(|prefix| name.starts_with(prefix))
-        || BAD_SUFFIXES.iter().any(|suffix| name.ends_with(suffix))
+/// carve/unpack directory) that should be excluded from the output archive and
+/// ignored during rootfs detection.
+pub fn is_extraction_artifact(name: &str) -> bool {
+    ARTIFACT_PREFIXES
+        .iter()
+        .any(|prefix| name.starts_with(prefix))
+        || ARTIFACT_SUFFIXES
+            .iter()
+            .any(|suffix| name.ends_with(suffix))
 }
 
 /// Character or block special file. Serialized as "char"/"block".
@@ -314,8 +330,12 @@ mod tests {
     #[test]
     fn flags_bad_prefixes() {
         assert!(is_extraction_artifact("0.tar"));
+        assert!(is_extraction_artifact("0.tar.gz"));
         assert!(is_extraction_artifact("squashfs-root"));
         assert!(is_extraction_artifact("squashfs-root-0"));
+        // cpio-root must be stripped from output too, not just ignored during
+        // detection (the two used to live in separate, drift-prone lists).
+        assert!(is_extraction_artifact("cpio-root"));
     }
 
     #[test]

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -24,7 +24,11 @@ pub const MANIFEST_MAGIC: &[u8; 16] = b"made with fw2tar";
 const TRAILER_FRAME_VERSION: u16 = 1;
 
 static BAD_PREFIXES: &[&str] = &["0.tar", "squashfs-root"];
-static BAD_SUFFIXES: &[&str] = &["_extract", ".uncompressed", ".unknown"];
+// Extractor recursive-unpack directories created *in place* next to the file
+// they came from. unblob uses `<name>_extract`; binwalk v3 uses `<name>.extracted`
+// (and `decompressed.bin` chunks beneath it). These are not part of the firmware
+// and must never ride along into the output archive.
+static BAD_SUFFIXES: &[&str] = &["_extract", ".extracted", ".uncompressed", ".unknown"];
 
 /// True when a path component looks like an extractor artifact (an intermediate
 /// carve/unpack directory) that should be excluded from the output archive.
@@ -319,6 +323,8 @@ mod tests {
         assert!(is_extraction_artifact("firmware.bin_extract"));
         assert!(is_extraction_artifact("data.uncompressed"));
         assert!(is_extraction_artifact("blob.unknown"));
+        // binwalk v3 names its in-place recursion dirs `<name>.extracted`.
+        assert!(is_extraction_artifact("payload.tar.gz.extracted"));
     }
 
     #[test]

--- a/tests/BEHAVIOR.md
+++ b/tests/BEHAVIOR.md
@@ -188,16 +188,36 @@ does this for both (`ok`). binwalkv3 handles `squashfs_in_ext4` but not
 ### No-cruft gate (clean rootfs, no scaffolding)
 
 A correct fw2tar output is *only* the real rootfs. The underlying extractors
-build a tree full of scaffolding — unblob nests `*.extracted/` wrappers,
-`<offset>-<offset>` chunk directories, and (for a nested image) leaves the inner
-container file lying around. fw2tar is supposed to strip all of that and rebase
-onto the selected rootfs. The `check_behavior.py --strict-extras` mode fails on
-**any** archive entry that is not part of the canonical rootfs (`lost+found` is
-the one allowed filesystem artifact), and `run_in_container.sh` runs a dedicated
-**no-cruft gate** asserting zero unexpected entries for the full-fidelity cells
-(`squashfs`, `cpio`, and both nested fixtures). The nested fixtures are the
-important ones: that is exactly where the outer container image or an `.extracted`
-wrapper would leak into the output if the rootfs-selection/rebasing logic broke.
+build a tree full of scaffolding — unblob nests `<name>_extract/` wrappers,
+binwalk v3 nests `<name>.extracted/` wrappers, plus `<offset>-<offset>` /
+`decompressed.bin` chunk artifacts, and (for a nested image) the inner container
+file. fw2tar strips all of that during the tar walk (`archive.rs`
+`is_extraction_artifact`) and rebases onto the selected rootfs. The
+`check_behavior.py --strict-extras` mode fails on **any** archive entry that is
+not part of the canonical rootfs (`lost+found` is the one allowed filesystem
+artifact), and `run_in_container.sh` runs a dedicated **no-cruft gate** asserting
+zero unexpected entries for the full-fidelity cells (`squashfs`, `cpio`, and both
+nested fixtures).
+
+### Recursion-cruft gate (artifact embedded *inside* the rootfs)
+
+The sharper, real-world case: the genuine rootfs contains an extractable artifact
+(a `.tar.gz`, a nested image, a compressed blob), and the extractor recursively
+unpacks it **in place**, creating a sibling unpack directory right next to the
+file *inside the rootfs tree*. That directory is not firmware and must not leak
+into the output — but the artifact file itself must survive. The recursion-cruft
+gate builds a rootfs carrying an embedded `usr/share/payload.tar.gz`
+(`build_rootfs.py --embed-artifact`), extracts it with every extractor, and for
+each one that produces a rootfs asserts the output is exactly *rootfs + the
+artifact file*, with nothing unpacked from it (`--strict-extras`).
+
+This caught a real bug: fw2tar's artifact-suffix list had `_extract` (unblob's
+naming) but not `.extracted` (binwalk v3's), so **binwalk v3's in-tree recursion
+directories — including the unpacked inner files — leaked into the archive**.
+Fixed by adding `.extracted` to `BAD_SUFFIXES` in both `archive.rs` (output strip)
+and `directory_executables.rs` (rootfs detection). All three extractors are now
+clean on both `squashfs` and `ext4` carriers (binwalk/binwalkv3 produce no ext
+rootfs, so those cells are reported, not gated).
 
 ### Caveats / gaps
 

--- a/tests/BEHAVIOR.md
+++ b/tests/BEHAVIOR.md
@@ -211,13 +211,28 @@ gate builds a rootfs carrying an embedded `usr/share/payload.tar.gz`
 each one that produces a rootfs asserts the output is exactly *rootfs + the
 artifact file*, with nothing unpacked from it (`--strict-extras`).
 
-This caught a real bug: fw2tar's artifact-suffix list had `_extract` (unblob's
+This caught a real bug: fw2tar's artifact-name list had `_extract` (unblob's
 naming) but not `.extracted` (binwalk v3's), so **binwalk v3's in-tree recursion
 directories — including the unpacked inner files — leaked into the archive**.
-Fixed by adding `.extracted` to `BAD_SUFFIXES` in both `archive.rs` (output strip)
-and `directory_executables.rs` (rootfs detection). All three extractors are now
-clean on both `squashfs` and `ext4` carriers (binwalk/binwalkv3 produce no ext
-rootfs, so those cells are reported, not gated).
+The root cause was structural: the output-strip (`archive.rs`) and the
+rootfs-detection ignore-list (`directory_executables.rs`) were two separate
+hand-maintained lists that had drifted. They are now a **single shared
+`is_extraction_artifact`** (in `archive.rs`, used by both), covering every
+convention observed across the extractors:
+
+| convention | extractor | match |
+|---|---|---|
+| `<name>_extract` | unblob | suffix `_extract` |
+| `<name>.uncompressed` / `.unknown` | unblob carve chunks | suffix |
+| `<name>.extracted` (+ nested `0/`, `decompressed.bin`) | binwalk v3 | suffix `.extracted` |
+| `squashfs-root`, `squashfs-root-0` | binwalk | prefix `squashfs-root` |
+| `cpio-root` | binwalk | prefix `cpio-root` |
+| `0.tar`, `0.tar.gz` | binwalk | prefix `0.tar` |
+
+All three extractors are now clean on both `squashfs` and `ext4` carriers
+(binwalk/binwalkv3 produce no ext rootfs, so those cells are reported, not gated).
+Enumerated empirically by running each extractor directly and confirming every
+recursion-dir name it emits matches a rule above.
 
 ### Caveats / gaps
 

--- a/tests/BEHAVIOR.md
+++ b/tests/BEHAVIOR.md
@@ -83,6 +83,8 @@ fat        none         none         none
 cpio       ok           ok           diff:6
 tar        ok           ok           ok
 zip        diff:6       diff:4       diff:6
+squashfs_in_ext4 ok     none         ok
+ext4_in_tar      ok     none         none
 ```
 
 `ok` = full fidelity · `diff:N` = rootfs produced but N metadata mismatches ·
@@ -167,6 +169,36 @@ across all types.
   but no file comes out executable, so — like the 7z types — the tree fails rootfs
   detection and no archive is produced. Encoded as `no-rootfs`.
 
+### Nested filesystems (file type in another type)
+
+Real firmware rarely ships a bare filesystem — the rootfs is usually carried
+*inside* another container (a boot filesystem, a partitioned disk image). Two
+fixtures exercise this directly by packing the canonical rootfs as an **inner**
+filesystem inside an **outer** one:
+
+- `squashfs_in_ext4` — an inner squashfs image stored inside an outer ext4.
+- `ext4_in_tar` — an inner ext4 image stored inside an outer tar.
+
+The contract here is *selection + fidelity*: fw2tar must recurse through the
+outer layer, recognise the inner tree as the real Linux rootfs (the outer layer
+holds a single image file, not a rootfs), and emit it at full fidelity. **unblob**
+does this for both (`ok`). binwalkv3 handles `squashfs_in_ext4` but not
+`ext4_in_tar`; binwalk recurses into neither (it doesn't produce an ext rootfs).
+
+### No-cruft gate (clean rootfs, no scaffolding)
+
+A correct fw2tar output is *only* the real rootfs. The underlying extractors
+build a tree full of scaffolding — unblob nests `*.extracted/` wrappers,
+`<offset>-<offset>` chunk directories, and (for a nested image) leaves the inner
+container file lying around. fw2tar is supposed to strip all of that and rebase
+onto the selected rootfs. The `check_behavior.py --strict-extras` mode fails on
+**any** archive entry that is not part of the canonical rootfs (`lost+found` is
+the one allowed filesystem artifact), and `run_in_container.sh` runs a dedicated
+**no-cruft gate** asserting zero unexpected entries for the full-fidelity cells
+(`squashfs`, `cpio`, and both nested fixtures). The nested fixtures are the
+important ones: that is exactly where the outer container image or an `.extracted`
+wrapper would leak into the output if the rootfs-selection/rebasing logic broke.
+
 ### Caveats / gaps
 
 - **Issue #52 ("everything → 0700").** A *clean* synthetic ext4 never reproduced the
@@ -174,8 +206,10 @@ across all types.
   (including restrictive ones), losing only the special bits, which the extfs handler now
   restores (rehosting/unblob#8). The original catastrophic collapse was likely specific
   to an older `e2fsprogs`/`debugfs` or the real OpenWrt **combined disk image** (partition
-  table → nested partition → ext4). Worth adding that real image to the **nightly** suite
-  to confirm the collapse path is also covered, before fully closing #52.
+  table → nested partition → ext4). That real image is now in the **nightly** suite
+  (`end_to_end.sh`, with a mode-capturing baseline — `/tmp` 1777 etc.), covering the
+  combined-disk path end-to-end; the `squashfs_in_ext4`/`ext4_in_tar` fixtures cover the
+  synthetic fs-in-fs path on every run.
 
 - **Big-endian cramfs (#5)** is uncovered: `mkfs.cramfs` emits host-endian (LE) only,
   which is why LE cramfs is green. A cross-endian fixture (or the real SRX5308 image in

--- a/tests/behavior/build_rootfs.py
+++ b/tests/behavior/build_rootfs.py
@@ -15,10 +15,12 @@ Run unprivileged. Modes (including suid/sgid/sticky) are set with chmod; ownersh
 is whatever the building user has (the characterization focuses on MODES, which is
 where issue #52 bites).
 """
+import argparse
+import gzip
+import io
 import json
 import os
-import stat
-import sys
+import tarfile
 from pathlib import Path
 
 # (relative path, octal mode). Directories end with "/".
@@ -61,7 +63,29 @@ SYMLINKS = [
 ]
 
 
-def build(root: Path) -> dict:
+# An extractable artifact that lives *inside* the real rootfs. Extractors will
+# recursively unpack it in place (unblob -> `payload.tar.gz_extract/`, binwalk v3
+# -> `payload.tar.gz.extracted/`). The artifact FILE is real firmware content and
+# must survive; the recursive-unpack directory is scaffolding and must NOT appear
+# in the output. Only the file (not its unpacked contents) goes into `expected`.
+ARTIFACT_DIR = "usr/share/"
+ARTIFACT_PATH = "usr/share/payload.tar.gz"
+ARTIFACT_INNER = [("recursion_cruft_marker_a.txt", b"INNER A\n"),
+                  ("recursion_cruft_marker_b.txt", b"INNER B\n")]
+
+
+def _artifact_bytes() -> bytes:
+    """A deterministic .tar.gz that extractors will recurse into."""
+    raw = io.BytesIO()
+    with tarfile.open(fileobj=raw, mode="w") as tf:
+        for name, data in ARTIFACT_INNER:
+            ti = tarfile.TarInfo(name)
+            ti.size = len(data)
+            tf.addfile(ti, io.BytesIO(data))
+    return gzip.compress(raw.getvalue(), mtime=0)
+
+
+def build(root: Path, embed_artifact: bool = False) -> dict:
     expected: dict = {}
 
     # Root dir: fw2tar forces the archive root to 0755 (see archive.rs).
@@ -95,20 +119,36 @@ def build(root: Path) -> dict:
     for rel, mode in DIRS:
         os.chmod(root / rel, mode)
 
+    if embed_artifact:
+        d = root / ARTIFACT_DIR
+        d.mkdir(parents=True, exist_ok=True)
+        os.chmod(d, 0o755)
+        expected[ARTIFACT_DIR.rstrip("/")] = {"type": "directory", "mode": oct(0o755)}
+        data = _artifact_bytes()
+        p = root / ARTIFACT_PATH
+        p.write_bytes(data)
+        os.chmod(p, 0o644)
+        # Only the artifact file is expected; its unpacked contents must NOT appear.
+        expected[ARTIFACT_PATH] = {"type": "file", "mode": oct(0o644), "size": len(data)}
+
     return expected
 
 
 def main():
-    if len(sys.argv) != 3:
-        print(f"usage: {sys.argv[0]} <rootfs_dir> <expected.json>", file=sys.stderr)
-        sys.exit(2)
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("rootfs_dir")
+    ap.add_argument("expected_json")
+    ap.add_argument("--embed-artifact", action="store_true",
+                    help="also embed an extractable .tar.gz inside the rootfs to "
+                         "exercise the in-tree recursion-cruft strip")
+    args = ap.parse_args()
 
-    root = Path(sys.argv[1])
+    root = Path(args.rootfs_dir)
     root.mkdir(parents=True, exist_ok=True)
-    expected = build(root)
+    expected = build(root, embed_artifact=args.embed_artifact)
 
-    Path(sys.argv[2]).write_text(json.dumps(expected, indent=2, sort_keys=True))
-    print(f"built rootfs at {root} ({len(expected)} entries), expectations -> {sys.argv[2]}")
+    Path(args.expected_json).write_text(json.dumps(expected, indent=2, sort_keys=True))
+    print(f"built rootfs at {root} ({len(expected)} entries), expectations -> {args.expected_json}")
 
 
 if __name__ == "__main__":

--- a/tests/behavior/check_behavior.py
+++ b/tests/behavior/check_behavior.py
@@ -9,8 +9,12 @@ Two modes:
     instead, that's an XPASS (exit 3) — the bug got fixed and the fixture should
     be promoted to golden.
 
-Extra entries in the archive (e.g. ext4 `lost+found`) are ignored; we only assert
-the entries we deliberately created.
+Extra entries in the archive (e.g. ext4 `lost+found`) are ignored by default; we
+only assert the entries we deliberately created. With --strict-extras the check
+*also* fails on any entry that is NOT part of the canonical rootfs — this is how
+we assert fw2tar emits a clean rootfs and does not leak extractor scaffolding
+(unblob's `*.extracted` wrappers, `<offset>-<offset>` chunk dirs, `squashfs-root`,
+leftover container images, etc.).
 """
 import argparse
 import json
@@ -22,6 +26,28 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from tar_to_json import extract_tar_to_json  # noqa: E402
 
 PERM_BITS = 0o7777
+
+# Entries that a filesystem legitimately adds and fw2tar is not expected to strip.
+# ext* reserves lost+found; everything else under it is fair game too.
+ALLOWED_EXTRA_PREFIXES = ("lost+found",)
+
+
+def find_extras(expected: dict, actual: dict) -> list:
+    """Return actual entries that are neither expected nor an allowed FS artifact.
+
+    A non-empty result means fw2tar leaked something that isn't part of the real
+    rootfs — extractor scaffolding is the usual culprit.
+    """
+    extras = []
+    for key in sorted(actual):
+        if key == "" or key in expected:
+            continue
+        if any(
+            key == p or key.startswith(p + "/") for p in ALLOWED_EXTRA_PREFIXES
+        ):
+            continue
+        extras.append(key)
+    return extras
 
 
 def norm(path: str) -> str:
@@ -38,7 +64,12 @@ def load_actual(tar_path: str) -> dict:
     return {norm(k): v for k, v in raw.items()}
 
 
-def compare(expected: dict, actual: dict, types_only: bool = False) -> list:
+def compare(
+    expected: dict,
+    actual: dict,
+    types_only: bool = False,
+    strict_extras: bool = False,
+) -> list:
     """Return a list of human-readable mismatch strings (empty == perfect match).
 
     With types_only=True (for filesystems that cannot carry unix metadata, e.g.
@@ -71,6 +102,9 @@ def compare(expected: dict, actual: dict, types_only: bool = False) -> list:
                 problems.append(
                     f"{disp}: mode {act_mode:#o} != expected {exp_mode:#o}"
                 )
+    if strict_extras:
+        for extra in find_extras(expected, actual):
+            problems.append(f"{extra}: UNEXPECTED extra entry (cruft?)")
     return problems
 
 
@@ -84,6 +118,9 @@ def main():
     ap.add_argument("--types-only", action="store_true",
                     help="assert only presence + file/dir type (for FAT etc. that "
                          "cannot carry unix modes/symlinks)")
+    ap.add_argument("--strict-extras", action="store_true",
+                    help="also fail on entries that are NOT part of the canonical "
+                         "rootfs (extractor scaffolding / cruft); lost+found is allowed")
     ap.add_argument("--report", action="store_true",
                     help="machine-readable: print the mismatch count to stdout "
                          "(0 = perfect), detail to stderr, and always exit 0")
@@ -96,7 +133,8 @@ def main():
         if not actual:
             print("ERR")
             return 0
-        problems = compare(expected, actual, types_only=args.types_only)
+        problems = compare(expected, actual, types_only=args.types_only,
+                           strict_extras=args.strict_extras)
         print(len(problems))
         for p in problems:
             print(f"    - {p}", file=sys.stderr)
@@ -106,7 +144,8 @@ def main():
         print(f"[{args.name}] ERROR: archive {args.tar} is empty or unreadable")
         return 1
 
-    problems = compare(expected, actual, types_only=args.types_only)
+    problems = compare(expected, actual, types_only=args.types_only,
+                       strict_extras=args.strict_extras)
 
     if args.expect_bug:
         if problems:

--- a/tests/behavior/make_images.sh
+++ b/tests/behavior/make_images.sh
@@ -124,9 +124,35 @@ build_fat() {
     echo "built $OUT/rootfs.fat"
 }
 
+# --- nested fixtures: a real filesystem carried INSIDE another container ---
+# These mirror how firmware actually ships (a rootfs image embedded in a boot
+# filesystem / disk image) and exercise fw2tar's job of recursing through the
+# outer layer, selecting the inner Linux rootfs, and emitting it cleanly without
+# the extractor's nesting scaffolding.
+
+build_squashfs_in_ext4() {  # inner squashfs, wrapped in an outer ext4
+    rm -f "$OUT/rootfs.sqfs_in_ext4"
+    local stage="$TMP/sqfs_in_ext4"
+    rm -rf "$stage"; mkdir -p "$stage"
+    mksquashfs "$ROOT" "$stage/rootfs.squashfs" -noappend -no-progress >/dev/null
+    mke2fs -q -F -t ext4 -b 1024 -d "$stage" "$OUT/rootfs.sqfs_in_ext4" 16384
+    echo "built $OUT/rootfs.sqfs_in_ext4"
+}
+
+build_ext4_in_tar() {  # inner ext4, wrapped in an outer tar
+    rm -f "$OUT/rootfs.ext4_in_tar"
+    local stage="$TMP/ext4_in_tar"
+    rm -rf "$stage"; mkdir -p "$stage"
+    mke2fs -q -F -t ext4 -b 1024 -d "$ROOT" "$stage/rootfs.ext4" 16384
+    tar --numeric-owner -C "$stage" -cf "$OUT/rootfs.ext4_in_tar" .
+    echo "built $OUT/rootfs.ext4_in_tar"
+}
+
 for t in "${TYPES[@]}"; do
     case "$t" in
         ext2|ext3|ext4) build_extfs "$t" ;;
+        squashfs_in_ext4) build_squashfs_in_ext4 ;;
+        ext4_in_tar)      build_ext4_in_tar ;;
         squashfs) build_squashfs ;;
         cramfs)   build_cramfs ;;
         jffs2)    build_jffs2 ;;

--- a/tests/behavior/run_in_container.sh
+++ b/tests/behavior/run_in_container.sh
@@ -212,6 +212,48 @@ for cell in "${NOCRUFT_CELLS[@]}"; do
     fi
 done
 
+# ---- recursion-cruft gate ----
+# The case that actually bites: an extractable artifact (here a .tar.gz) living
+# INSIDE the real rootfs. Extractors recursively unpack it in place next to the
+# file (unblob -> `payload.tar.gz_extract/`, binwalk v3 -> `payload.tar.gz.extracted/`),
+# and that scaffolding must NOT ride along into the output — but the artifact
+# FILE itself must survive. Build a rootfs carrying the artifact, extract it with
+# every extractor, and for every extractor that produces a rootfs assert the
+# output is exactly the rootfs + the artifact file and nothing unpacked from it.
+RECURSION_TYPES=(squashfs ext4)
+ART_SRC="$WORK/rootfs_artifact"
+ART_EXPECTED="$WORK/expected_artifact.json"
+ART_IMAGES="$WORK/images_artifact"
+echo
+echo "== recursion-cruft gate (artifact embedded inside the rootfs) =="
+"$BEHAVIOR/build_rootfs.py" --embed-artifact "$ART_SRC" "$ART_EXPECTED" >/dev/null || exit 1
+mkdir -p "$ART_IMAGES"
+"$BEHAVIOR/make_images.sh" "$ART_SRC" "$ART_IMAGES" "${RECURSION_TYPES[@]}" >/dev/null || exit 1
+for t in "${RECURSION_TYPES[@]}"; do
+    img="$ART_IMAGES/rootfs.$t"
+    [ -f "$img" ] || continue
+    for e in "${EXTRACTORS[@]}"; do
+        outdir="$WORK/out_artifact_${t}_${e}"; mkdir -p "$outdir"
+        fakeroot_fw2tar "$img" --output "$outdir/art" --extractors "$e" \
+            --timeout 120 --force >"$WORK/artifact_${t}_${e}.log" 2>&1
+        rootfs="$(find "$outdir" -name '*.rootfs.tar.gz' 2>/dev/null | head -1)"
+        if [ -z "$rootfs" ] || [ ! -f "$rootfs" ]; then
+            echo -e "${YELLOW}recursion-cruft $t/$e: no rootfs (not gated)${END}"
+            continue
+        fi
+        n="$("$BEHAVIOR/check_behavior.py" --tar "$rootfs" --expected "$ART_EXPECTED" \
+              --name "artifact_${t}_${e}" --strict-extras --report \
+              2>"$WORK/artifact_${t}_${e}.cruft")"
+        if [ "$n" = "0" ]; then
+            echo -e "${GREEN}recursion-cruft $t/$e: clean (artifact kept, recursion stripped)${END}"
+        else
+            echo -e "${RED}RECURSION-CRUFT $t/$e: $n leaked/mismatched entr(y/ies)${END}"
+            head -8 "$WORK/artifact_${t}_${e}.cruft" 2>/dev/null | while IFS= read -r l; do echo "    $l"; done
+            failures=$((failures+1))
+        fi
+    done
+done
+
 echo
 if [ "$failures" -eq 0 ]; then
     echo -e "${GREEN}behavior: matrix matches expectations${END}"

--- a/tests/behavior/run_in_container.sh
+++ b/tests/behavior/run_in_container.sh
@@ -36,6 +36,10 @@ FIXTURES=(
     "cpio|rootfs.cpio"
     "tar|rootfs.tar"
     "zip|rootfs.zip"
+    # nested: a real filesystem carried inside another container (firmware shape).
+    # Exercises recursion + inner-rootfs selection; gated for cruft below.
+    "squashfs_in_ext4|rootfs.sqfs_in_ext4"
+    "ext4_in_tar|rootfs.ext4_in_tar"
 )
 
 # Expected outcome per "<fixture>/<extractor>" cell:
@@ -66,6 +70,10 @@ declare -A EXPECT=(
     [cpio/unblob]=ok        [cpio/binwalk]=ok        [cpio/binwalkv3]=diff:6
     [tar/unblob]=ok         [tar/binwalk]=ok         [tar/binwalkv3]=ok
     [zip/unblob]=diff:6     [zip/binwalk]=diff:4     [zip/binwalkv3]=diff:6
+    # nested fixtures (baselined 2026-06-28): the inner rootfs must be selected
+    # through the outer container with full fidelity for unblob.
+    [squashfs_in_ext4/unblob]=ok  [squashfs_in_ext4/binwalk]=none [squashfs_in_ext4/binwalkv3]=ok
+    [ext4_in_tar/unblob]=ok       [ext4_in_tar/binwalk]=none      [ext4_in_tar/binwalkv3]=none
 )
 
 # Optional fixture subset (positional args). Empty => all fixtures.
@@ -80,7 +88,8 @@ declare -A type_for=( [rootfs.ext2]=ext2 [rootfs.ext3]=ext3 [rootfs.ext4]=ext4 \
     [rootfs.squashfs]=squashfs [rootfs.cramfs]=cramfs [rootfs.jffs2]=jffs2 \
     [rootfs.ubifs]=ubifs [rootfs.iso]=iso9660 [rootfs.fat]=fat \
     [rootfs.romfs]=romfs [rootfs.yaffs2]=yaffs \
-    [rootfs.cpio]=cpio [rootfs.tar]=tar [rootfs.zip]=zip )
+    [rootfs.cpio]=cpio [rootfs.tar]=tar [rootfs.zip]=zip \
+    [rootfs.sqfs_in_ext4]=squashfs_in_ext4 [rootfs.ext4_in_tar]=ext4_in_tar )
 
 ROOTFS_SRC="$WORK/rootfs_src"
 EXPECTED="$WORK/expected.json"
@@ -170,6 +179,35 @@ for key in "${!EXPECT[@]}"; do
     esac
     if [ "$got" != "$want" ]; then
         echo -e "${RED}REGRESSION $key: expected $want, got ${CELL[$key]:-MISSING}${END}"
+        failures=$((failures+1))
+    fi
+done
+
+# ---- no-cruft gate ----
+# A correct fw2tar output is ONLY the real rootfs: no extractor scaffolding
+# (unblob's `*.extracted` wrappers, `<offset>-<offset>` chunk dirs, leftover
+# container images from a nested extraction, etc.). For cells that produce a
+# full-fidelity rootfs, additionally assert there are zero unexpected entries
+# (--strict-extras; lost+found is allowed). Nested fixtures are the important
+# case — that is where the scaffolding would otherwise leak in.
+NOCRUFT_CELLS=(squashfs/unblob cpio/unblob squashfs_in_ext4/unblob ext4_in_tar/unblob)
+echo
+echo "== no-cruft gate =="
+for cell in "${NOCRUFT_CELLS[@]}"; do
+    name="${cell%%/*}"; extractor="${cell##*/}"
+    want_fixture "$name" || continue
+    rootfs="$(find "$WORK/out_${name}_${extractor}" -name '*.rootfs.tar.gz' 2>/dev/null | head -1)"
+    if [ -z "$rootfs" ] || [ ! -f "$rootfs" ]; then
+        echo -e "${RED}NO-CRUFT $cell: no rootfs produced${END}"
+        failures=$((failures+1)); continue
+    fi
+    n="$("$BEHAVIOR/check_behavior.py" --tar "$rootfs" --expected "$EXPECTED" \
+          --name "$name" --strict-extras --report 2>"$WORK/${name}_${extractor}.cruft")"
+    if [ "$n" = "0" ]; then
+        echo -e "${GREEN}no-cruft $cell: clean${END}"
+    else
+        echo -e "${RED}NO-CRUFT $cell: $n unexpected/mismatched entr(y/ies)${END}"
+        sed 's/^/    /' "$WORK/${name}_${extractor}.cruft" >&2 2>/dev/null || true
         failures=$((failures+1))
     fi
 done


### PR DESCRIPTION
Adds two test capabilities to the behavior characterization harness.

## 1. File type in another type (nested filesystems)
Every fixture previously packed the canonical rootfs as a single bare filesystem, but real firmware carries the rootfs *inside* an outer container. Two new fixtures pack it as an inner image inside an outer one:
- `squashfs_in_ext4` — inner squashfs inside an outer ext4
- `ext4_in_tar` — inner ext4 inside an outer tar

They assert fw2tar recurses through the outer layer, selects the **inner** Linux rootfs (the outer holds a single image file, not a rootfs), and emits it at full fidelity. Baselined: `unblob = ok` for both; binwalkv3 handles `squashfs_in_ext4` only; binwalk recurses into neither. Pinned in the `EXPECT` matrix.

## 2. Correctness: no cruft / extra folders
`check_behavior.py` ignored extra archive entries, so nothing caught fw2tar leaking extractor scaffolding (unblob's `*.extracted` wrappers, `<offset>-<offset>` chunk dirs, a leftover inner container image). Added:
- `check_behavior.py --strict-extras` — fails on **any** entry not part of the canonical rootfs (`lost+found` allowed).
- A dedicated **no-cruft gate** in `run_in_container.sh` asserting zero unexpected entries for the full-fidelity cells (`squashfs`, `cpio`, and both nested fixtures). Verified it has teeth: injecting a `rootfs.squashfs.extracted` dir into a clean output makes it fail.

The nested fixtures are exactly where scaffolding would leak if rootfs selection/rebasing broke, so they get the strictest check.

## Validation
Full `./tests/behavior/run.sh` matrix green including the new rows and the no-cruft gate; `check_behavior.py` lints clean (ruff) and `py_compile`s. BEHAVIOR.md updated (matrix rows, a nested-filesystems section, and a no-cruft-gate section).