### PR TITLE
Keep secondary root filesystems under --primary-limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ fw2tar /path/to/your/firmware.bin
 
 Which will generate `/path/to/your/firmware.rootfs.tar.gz` containing the rootfs of the firmware.
 
+Some firmware splits its filesystem across more than one image (for example a
+main rootfs plus a separate `/opt` image). Raise `--primary-limit` to keep the
+extra root-like filesystems too; the best one is still written to
+`firmware.rootfs.tar.gz`, and each additional filesystem (from the same
+extractor) is written alongside it as `firmware.<N>.rootfs.tar.gz`
+(`firmware.1.rootfs.tar.gz`, `firmware.2.rootfs.tar.gz`, …). A consumer can then
+mount each where the device expects it.
+
 There are two types of arguments, wrapper arguments (which handle anything outside of the fw2tar docker container, such as rebuilding the container or specifying a docker image tag) and fw2tar flags (which get passed to the actual application). These can be found with `--wrapper-help` and `--help` respectively.
 
 ### Installing Pre-built

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,16 @@ fn rootfs_archive_path(output_base: &Path) -> PathBuf {
     output_base.with_file_name(format!("{}.rootfs.tar.gz", file_name))
 }
 
+/// Path for a secondary root-like filesystem (index >= 1) when `--primary-limit`
+/// is raised above 1: `<base>.<index>.rootfs.tar.gz`, sitting next to the primary
+/// `<base>.rootfs.tar.gz`. Some firmware splits its rootfs across several
+/// filesystems (e.g. a main image plus an `/opt` image); a consumer can mount
+/// these where the device expects them.
+fn secondary_archive_path(output_base: &Path, index: usize) -> PathBuf {
+    let file_name = output_base.file_name().unwrap().to_string_lossy();
+    output_base.with_file_name(format!("{file_name}.{index}.rootfs.tar.gz"))
+}
+
 pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
     if !args.firmware.is_file() {
         if args.firmware.exists() {
@@ -127,15 +137,43 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
     };
 
     let best_result = best_results[0];
+    let winning_extractor = best_result.extractor;
 
     fs::rename(&best_result.path, &selected_output_path)
         .map_err(|e| Fw2tarError::OutputWrite(selected_output_path.clone(), e))?;
 
     write_manifest_sidecar(&best_result.manifest, &selected_output_path);
 
-    // The winning archive was renamed to `selected_output_path`; everything else
-    // produced during the run (losing candidate tarballs, per-extractor logs) is
-    // intermediate scratch the user did not ask for. Sweep it up on success.
+    // Secondary filesystems (index >= 1) from the SAME winning extractor: when
+    // `--primary-limit` is raised, some firmware splits its rootfs across several
+    // images (e.g. a main image plus an `/opt` image). Keep those, named
+    // `<base>.<index>.rootfs.tar.gz`, so a consumer can mount them; they are tied
+    // to the winning extractor so the set is internally consistent. They are
+    // renamed away from their candidate paths here, so the cleanup below (which
+    // only removes paths that still exist) leaves them in place.
+    for sec in results
+        .iter()
+        .filter(|res| res.extractor == winning_extractor && res.index >= 1)
+    {
+        let sec_path = secondary_archive_path(&output, sec.index);
+        match fs::rename(&sec.path, &sec_path) {
+            Ok(()) => {
+                eprintln!(
+                    "fw2tar: secondary filesystem #{i} ({extractor}), archive at {path:?}",
+                    i = sec.index,
+                    extractor = winning_extractor,
+                    path = sec_path,
+                );
+                write_manifest_sidecar(&sec.manifest, &sec_path);
+            }
+            Err(e) => log::warn!("failed to keep secondary filesystem {:?}: {e}", sec.path),
+        }
+    }
+
+    // The winning archive was renamed to `selected_output_path` and any secondary
+    // filesystems were renamed to their `<base>.<index>.rootfs.tar.gz` paths;
+    // everything else produced during the run (losing candidate tarballs,
+    // per-extractor logs) is intermediate scratch. Sweep it up on success.
     cleanup_stray_artifacts(&results, &extractors, &output, args.loud);
 
     Ok((result, selected_output_path))
@@ -248,6 +286,20 @@ mod tests {
         assert_eq!(
             rootfs_archive_path(Path::new("/out/dir/firmware")),
             PathBuf::from("/out/dir/firmware.rootfs.tar.gz")
+        );
+    }
+
+    #[test]
+    fn secondary_archive_path_inserts_index_before_rootfs_suffix() {
+        // Secondary filesystems sit next to the primary, distinguished by index,
+        // and (like the primary) must not greedily strip dotted version segments.
+        assert_eq!(
+            secondary_archive_path(Path::new("/out/dir/firmware"), 1),
+            PathBuf::from("/out/dir/firmware.1.rootfs.tar.gz")
+        );
+        assert_eq!(
+            secondary_archive_path(Path::new("RAX54Sv2-V1.1.4.28"), 2),
+            PathBuf::from("RAX54Sv2-V1.1.4.28.2.rootfs.tar.gz")
         );
     }
 }


### PR DESCRIPTION
## Problem (seen in the wild)
Some firmware splits its filesystem across more than one image — a main rootfs plus a separate `/opt` image. Two rehosting Dockerfiles (`cambium/cnPilot-R190`, `flyingvoice/fwr8102`) handled this by running `fw2tar --primary_limit 2` and merging the two candidate archives:
```sh
tar xf input_file.binwalk.0.tar.gz -C combined        # main rootfs
tar xf input_file.binwalk.1.tar.gz -C combined/opt    # second fs -> /opt
```
After the single-best-output redesign, fw2tar still *extracts* up to `--primary-limit` filesystems but keeps only index 0 and **deletes the rest in cleanup** — so the secondary fs is unrecoverable. Those devices now lose their `/opt` filesystem entirely. (Downstream this surfaced as an empty 104-byte rootfs shipping with exit 0, because the consumer's `sh -c` lacked `set -e`; that's a consumer fix, tracked separately.)

## Fix
Keep the additional root-like filesystems **from the winning extractor**, written next to the primary as `<base>.<index>.rootfs.tar.gz` (`<base>.1.rootfs.tar.gz`, `<base>.2…`), each with its manifest sidecar. They're renamed away from their candidate paths before `cleanup_stray_artifacts` runs (which only deletes paths that still exist), so they survive. Default behavior is unchanged: `--primary-limit` defaults to 1, so a normal run still produces exactly `<base>.rootfs.tar.gz`.

Tying secondaries to the winning extractor keeps the set internally consistent, and the index ordering is the same `find_linux_filesystems` ranking the old `.0`/`.1` scheme used — so main=0 / opt=1 semantics carry over.

## Validation
- `cargo test` (19 passed) incl. a new `secondary_archive_path` naming test; `cargo build`/`clippy` clean (no new warnings).
- End-to-end against a freshly-built `.#testImage`: a tar containing two ext4 rootfs images run with `--primary_limit 2` produced **both** `input_file.rootfs.tar.gz` and `input_file.1.rootfs.tar.gz` with the correct distinct contents + manifest sidecars.
- README documents the `<base>.<N>.rootfs.tar.gz` output.

## Follow-up (separate, depends on this)
Once this lands and an image publishes, migrate the two Dockerfiles to the new filenames (`*.rootfs.tar.gz` / `*.1.rootfs.tar.gz`), add `set -e`, and bump their `FW2TAR` pin to the image carrying this change.