### PR TITLE
Restore stable per-candidate output contract; expose secondary_filesystems in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,22 @@ Once installed, repackaging a firmware is as simple as:
 fw2tar /path/to/your/firmware.bin
 ```
 
-Which will generate `/path/to/your/firmware.rootfs.tar.gz` containing the rootfs of the firmware.
+This produces two kinds of output:
+
+- One archive per extractor per candidate root filesystem, named
+  `firmware.<extractor>.<N>.tar.gz` (e.g. `firmware.unblob.0.tar.gz`,
+  `firmware.binwalk.0.tar.gz`). This is fw2tar's stable, long-standing output
+  contract — every extraction is kept so a consumer can pick.
+- `firmware.rootfs.tar.gz`, a convenience copy of the best extraction, so the
+  common "just give me the rootfs" case needs no extractor choice.
 
 Some firmware splits its filesystem across more than one image (for example a
 main rootfs plus a separate `/opt` image). Raise `--primary-limit` to keep the
-extra root-like filesystems too; the best one is still written to
-`firmware.rootfs.tar.gz`, and each additional filesystem (from the same
-extractor) is written alongside it as `firmware.<N>.rootfs.tar.gz`
-(`firmware.1.rootfs.tar.gz`, `firmware.2.rootfs.tar.gz`, …). A consumer can then
-mount each where the device expects it.
+extra root-like filesystems too; each additional filesystem from the winning
+extractor is written alongside the primary as `firmware.<N>.rootfs.tar.gz`
+(`firmware.1.rootfs.tar.gz`, `firmware.2.rootfs.tar.gz`, …), and the primary's
+manifest lists them under `secondary_filesystems` so a consumer can discover the
+full set without hardcoding filenames.
 
 There are two types of arguments, wrapper arguments (which handle anything outside of the fw2tar docker container, such as rebuilding the container or specifying a docker image tag) and fw2tar flags (which get passed to the actual application). These can be found with `--wrapper-help` and `--help` respectively.
 
@@ -86,7 +93,7 @@ Replace `/path/to/your/firmware.bin` with the actual path to your firmware file:
 ./fw2tar /path/to/your/firmware.bin
 ```
 
-The resulting filesystem(s) will be output to `/path/to/your/firmware.{binwalk,unblob}.*.tar.gz`, with each root filesystem extracted to its own archive.
+The resulting filesystem(s) will be output to `/path/to/your/firmware.{binwalk,unblob}.*.tar.gz`, with each root filesystem extracted to its own archive, plus a `firmware.rootfs.tar.gz` convenience copy of the best extraction (see [Usage](#usage) above).
 
 ## Comparing Filesystem Archives
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -232,6 +232,21 @@ pub fn write_manifest_trailer<W: Write>(writer: &mut W, manifest: &Manifest) -> 
     Ok(())
 }
 
+/// Append a fresh manifest trailer to an existing fw2tar archive as a new gzip
+/// member. Gzip members concatenate transparently on decompression and
+/// `parse_manifest_trailer` reads from the very end, so the appended trailer
+/// supersedes any earlier one (the stale bytes mid-stream are never read). Used
+/// to reconcile a *derived* archive's embedded manifest with its sidecar — e.g.
+/// the primary is copied byte-for-byte from a winning candidate whose trailer
+/// predates the secondary-filesystem list, and this rewrites it to match.
+pub fn append_manifest_trailer(archive_path: &Path, manifest: &Manifest) -> io::Result<()> {
+    let file = fs::OpenOptions::new().append(true).open(archive_path)?;
+    let mut encoder = GzEncoder::new(file, Compression::default());
+    write_manifest_trailer(&mut encoder, manifest)?;
+    encoder.finish()?;
+    Ok(())
+}
+
 /// Parse a manifest from the tail of a decompressed fw2tar stream (the inverse
 /// of `write_manifest_trailer`). Returns `None` if the magic is absent or the
 /// framing is malformed.
@@ -262,10 +277,11 @@ pub fn parse_manifest_trailer(decompressed: &[u8]) -> Option<Manifest> {
 #[cfg(test)]
 mod tests {
     use super::{
-        is_extraction_artifact, parse_manifest_trailer, write_manifest_trailer, DeviceKind,
-        RemovedDevice,
+        append_manifest_trailer, is_extraction_artifact, parse_manifest_trailer,
+        write_manifest_trailer, Compression, DeviceKind, File, GzEncoder, RemovedDevice,
     };
-    use crate::metadata::{Manifest, Metadata, MANIFEST_VERSION};
+    use crate::metadata::{Manifest, Metadata, SecondaryFilesystem, MANIFEST_VERSION};
+    use std::io::{Read, Write};
 
     fn sample_manifest() -> Manifest {
         Manifest::new(
@@ -300,6 +316,46 @@ mod tests {
         assert_eq!(parsed.devices.len(), 1);
         assert_eq!(parsed.devices[0].path, "/dev/console");
         assert_eq!(parsed.devices[0].major, 5);
+    }
+
+    #[test]
+    fn appended_trailer_supersedes_earlier_one() {
+        // A derived archive: an initial gzip member ending in a secondary-free
+        // trailer, then an appended member carrying the updated manifest. After
+        // decompression the parser must recover the *appended* manifest from the
+        // tail — this is how the copied primary's trailer is reconciled with its
+        // sidecar.
+        use flate2::read::MultiGzDecoder;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("primary.rootfs.tar.gz");
+
+        {
+            let f = File::create(&path).unwrap();
+            let mut enc = GzEncoder::new(f, Compression::default());
+            enc.write_all(b"stand-in for the tar payload").unwrap();
+            write_manifest_trailer(&mut enc, &sample_manifest()).unwrap();
+            enc.finish().unwrap();
+        }
+
+        let mut updated = sample_manifest();
+        updated.secondary_filesystems = vec![SecondaryFilesystem {
+            index: 1,
+            archive: "primary.1.rootfs.tar.gz".into(),
+        }];
+        append_manifest_trailer(&path, &updated).unwrap();
+
+        let mut decompressed = Vec::new();
+        MultiGzDecoder::new(File::open(&path).unwrap())
+            .read_to_end(&mut decompressed)
+            .unwrap();
+
+        let parsed = parse_manifest_trailer(&decompressed).expect("parse appended trailer");
+        assert_eq!(parsed.secondary_filesystems.len(), 1);
+        assert_eq!(
+            parsed.secondary_filesystems[0].archive,
+            "primary.1.rootfs.tar.gz"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod metadata;
 
 use analysis::{extract_and_process, extractor_log_path, ExtractionResult};
 pub use error::Fw2tarError;
-use metadata::{Manifest, Metadata};
+use metadata::{Manifest, Metadata, SecondaryFilesystem};
 
 use std::cmp::Reverse;
 use std::path::{Path, PathBuf};
@@ -47,6 +47,19 @@ fn rootfs_archive_path(output_base: &Path) -> PathBuf {
 fn secondary_archive_path(output_base: &Path, index: usize) -> PathBuf {
     let file_name = output_base.file_name().unwrap().to_string_lossy();
     output_base.with_file_name(format!("{file_name}.{index}.rootfs.tar.gz"))
+}
+
+/// Manifest descriptor for the secondary filesystem at `index`: its archive
+/// filename relative to the primary (they share a directory, so the bare file
+/// name is the relative path). Consumers resolve it against the primary's own
+/// location rather than hardcoding it.
+fn secondary_descriptor(output_base: &Path, index: usize) -> SecondaryFilesystem {
+    let archive = secondary_archive_path(output_base, index)
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    SecondaryFilesystem { index, archive }
 }
 
 pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
@@ -139,64 +152,81 @@ pub fn main(args: args::Args) -> Result<(BestExtractor, PathBuf), Fw2tarError> {
     let best_result = best_results[0];
     let winning_extractor = best_result.extractor;
 
-    fs::rename(&best_result.path, &selected_output_path)
+    // Copy (not rename) the winner to the stable `<base>.rootfs.tar.gz` name so
+    // its per-candidate `<base>.<extractor>.<index>.tar.gz` archive stays in
+    // place. fw2tar's long-standing front-facing contract is one archive per
+    // extractor per candidate filesystem (`<base>.{binwalk,unblob}.*.tar.gz`);
+    // consumers still rely on those names, so they are kept. The
+    // `<base>.rootfs.tar.gz` winner is an additional convenience on top.
+    fs::copy(&best_result.path, &selected_output_path)
         .map_err(|e| Fw2tarError::OutputWrite(selected_output_path.clone(), e))?;
-
-    write_manifest_sidecar(&best_result.manifest, &selected_output_path);
 
     // Secondary filesystems (index >= 1) from the SAME winning extractor: when
     // `--primary-limit` is raised, some firmware splits its rootfs across several
-    // images (e.g. a main image plus an `/opt` image). Keep those, named
-    // `<base>.<index>.rootfs.tar.gz`, so a consumer can mount them; they are tied
-    // to the winning extractor so the set is internally consistent. They are
-    // renamed away from their candidate paths here, so the cleanup below (which
-    // only removes paths that still exist) leaves them in place.
+    // images (e.g. a main image plus an `/opt` image). Copy those to
+    // `<base>.<index>.rootfs.tar.gz` so a consumer can mount them; they are tied
+    // to the winning extractor so the set is internally consistent. Record the
+    // ones that actually landed so the primary manifest can advertise the full
+    // set (issue #70). Their own sidecars are written after.
+    let mut secondary_filesystems = Vec::new();
+    let mut secondary_sidecars = Vec::new();
     for sec in results
         .iter()
         .filter(|res| res.extractor == winning_extractor && res.index >= 1)
     {
         let sec_path = secondary_archive_path(&output, sec.index);
-        match fs::rename(&sec.path, &sec_path) {
-            Ok(()) => {
+        match fs::copy(&sec.path, &sec_path) {
+            Ok(_) => {
                 eprintln!(
                     "fw2tar: secondary filesystem #{i} ({extractor}), archive at {path:?}",
                     i = sec.index,
                     extractor = winning_extractor,
                     path = sec_path,
                 );
-                write_manifest_sidecar(&sec.manifest, &sec_path);
+                secondary_filesystems.push(secondary_descriptor(&output, sec.index));
+                secondary_sidecars.push((sec.manifest.clone(), sec_path));
             }
             Err(e) => log::warn!("failed to keep secondary filesystem {:?}: {e}", sec.path),
         }
     }
+    secondary_filesystems.sort_by_key(|fs| fs.index);
 
-    // The winning archive was renamed to `selected_output_path` and any secondary
-    // filesystems were renamed to their `<base>.<index>.rootfs.tar.gz` paths;
-    // everything else produced during the run (losing candidate tarballs,
-    // per-extractor logs) is intermediate scratch. Sweep it up on success.
-    cleanup_stray_artifacts(&results, &extractors, &output, args.loud);
+    // The primary manifest advertises the secondary set. Built after the copies
+    // above so it only lists filesystems that actually landed on disk.
+    let mut primary_manifest = best_result.manifest.clone();
+    primary_manifest.secondary_filesystems = secondary_filesystems;
+    write_manifest_sidecar(&primary_manifest, &selected_output_path);
+
+    // The primary was copied from the winning candidate, so its embedded trailer
+    // still carries that candidate's original (secondary-free) manifest. When we
+    // added secondaries, reconcile the trailer with the sidecar so the two never
+    // diverge — the manifest is the same whether a consumer reads it from the
+    // gzip trailer or the sidecar. No-op when there are no secondaries (the copy
+    // already matches).
+    if !primary_manifest.secondary_filesystems.is_empty() {
+        if let Err(e) = archive::append_manifest_trailer(&selected_output_path, &primary_manifest) {
+            log::warn!("failed to reconcile primary manifest trailer: {e}");
+        }
+    }
+
+    for (manifest, sec_path) in &secondary_sidecars {
+        write_manifest_sidecar(manifest, sec_path);
+    }
+
+    // The per-candidate `<base>.<extractor>.<index>.tar.gz` archives are part of
+    // the output contract and are deliberately kept. Only the per-extractor logs
+    // are intermediate scratch to sweep up on success.
+    cleanup_extractor_logs(&extractors, &output, args.loud);
 
     Ok((result, selected_output_path))
 }
 
-/// Remove intermediate files left next to the output after a successful run:
-/// the non-selected candidate `*.tar.gz` archives (the winner has already been
-/// renamed away from its candidate path) and, unless running `--loud`, the
-/// per-extractor `*.log` files. Best-effort: failures are logged, never fatal.
-fn cleanup_stray_artifacts(
-    results: &[ExtractionResult],
-    requested_extractors: &[String],
-    output_base: &Path,
-    loud: bool,
-) {
-    for res in results {
-        if res.path.exists() {
-            if let Err(e) = fs::remove_file(&res.path) {
-                log::warn!("failed to remove intermediate archive {:?}: {e}", res.path);
-            }
-        }
-    }
-
+/// Remove the per-extractor `<base>.<extractor>.log` files left next to the
+/// output after a successful run (unless `--loud`). The per-candidate
+/// `<base>.<extractor>.<index>.tar.gz` archives are part of fw2tar's output
+/// contract and are deliberately preserved. Best-effort: failures are logged,
+/// never fatal.
+fn cleanup_extractor_logs(requested_extractors: &[String], output_base: &Path, loud: bool) {
     if loud {
         return;
     }
@@ -301,5 +331,19 @@ mod tests {
             secondary_archive_path(Path::new("RAX54Sv2-V1.1.4.28"), 2),
             PathBuf::from("RAX54Sv2-V1.1.4.28.2.rootfs.tar.gz")
         );
+    }
+
+    #[test]
+    fn secondary_descriptor_records_relative_archive_name() {
+        // The descriptor stored in the primary manifest must be the archive's
+        // name relative to the primary (bare basename), not an absolute path,
+        // and must preserve dotted version segments.
+        let d = secondary_descriptor(Path::new("/out/dir/firmware"), 1);
+        assert_eq!(d.index, 1);
+        assert_eq!(d.archive, "firmware.1.rootfs.tar.gz");
+
+        let d = secondary_descriptor(Path::new("RAX54Sv2-V1.1.4.28"), 2);
+        assert_eq!(d.index, 2);
+        assert_eq!(d.archive, "RAX54Sv2-V1.1.4.28.2.rootfs.tar.gz");
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,6 +17,23 @@ pub struct Metadata {
     pub fw2tar_command: Vec<String>,
 }
 
+/// Descriptor for a secondary root-like filesystem kept alongside the primary
+/// when `--primary-limit` is raised above 1. Recorded in the *primary's*
+/// manifest so a consumer can discover the full set of filesystems a run
+/// produced — and reassemble them — from the primary manifest alone, without
+/// hardcoding archive filenames per firmware.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SecondaryFilesystem {
+    /// Candidate index (>= 1) assigned during extraction; index 0 is the primary.
+    pub index: usize,
+    /// Archive filename relative to the primary (same directory), e.g.
+    /// `firmware.1.rootfs.tar.gz`.
+    pub archive: String,
+    // `mount` — the subpath within the primary where this filesystem is meant to
+    // mount — is intentionally not recorded yet: fw2tar does not currently infer
+    // it (see issue #70). Added later without a version bump, per the note above.
+}
+
 /// The versioned side-channel spec that fw2tar tacks onto its output: embedded
 /// in the gzip trailer after the tar EOF blocks (see `archive::write_manifest_trailer`)
 /// and also written verbatim as a `<archive>.manifest.json` sidecar. The tar
@@ -41,11 +58,17 @@ pub struct Manifest {
     /// the rehosted filesystem, so recording type + major/minor + mode makes
     /// the strip non-lossy.
     pub devices: Vec<RemovedDevice>,
-    // Reserved for future iterations (kept out of the emitted JSON until
-    // populated; adding them later is forward-compatible per the note above):
-    //   * `mounts` — where secondary filesystems would mount in the primary.
-    //   * `secondary_filesystems` — descriptors for (or payloads of) additional
-    //     candidate filesystems.
+
+    /// Secondary root-like filesystems this run produced from the *same*
+    /// (winning) extractor, populated only on the primary's manifest when
+    /// `--primary-limit` is raised above 1. Empty for the common single-rootfs
+    /// case, and `skip_serializing_if` keeps it out of the emitted JSON then, so
+    /// existing single-filesystem output is byte-identical.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secondary_filesystems: Vec<SecondaryFilesystem>,
+    // Reserved for a future iteration (forward-compatible per the note above):
+    //   * `mounts` — where each secondary filesystem mounts in the primary.
+    //     Deferred until fw2tar can infer the mount point (issue #70).
 }
 
 impl Manifest {
@@ -55,6 +78,72 @@ impl Manifest {
             input,
             extractor: extractor.to_string(),
             devices,
+            secondary_filesystems: Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_manifest() -> Manifest {
+        Manifest::new(
+            Metadata {
+                input_hash: "abc123".into(),
+                file: "firmware.bin".into(),
+                fw2tar_command: vec!["fw2tar".into(), "firmware.bin".into()],
+            },
+            "unblob",
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn empty_secondary_filesystems_omitted_from_json() {
+        // The common single-rootfs case must not gain a new key, so existing
+        // consumers and golden output stay byte-identical.
+        let json = serde_json::to_string(&sample_manifest()).unwrap();
+        assert!(
+            !json.contains("secondary_filesystems"),
+            "empty secondary list must be omitted, got: {json}"
+        );
+    }
+
+    #[test]
+    fn populated_secondary_filesystems_round_trip() {
+        let mut manifest = sample_manifest();
+        manifest.secondary_filesystems = vec![
+            SecondaryFilesystem {
+                index: 1,
+                archive: "firmware.1.rootfs.tar.gz".into(),
+            },
+            SecondaryFilesystem {
+                index: 2,
+                archive: "firmware.2.rootfs.tar.gz".into(),
+            },
+        ];
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        assert!(json.contains("secondary_filesystems"));
+
+        let parsed: Manifest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.secondary_filesystems, manifest.secondary_filesystems);
+    }
+
+    #[test]
+    fn manifest_without_secondary_key_deserializes() {
+        // A manifest written before this field existed (no key) must still load,
+        // defaulting to an empty list.
+        let legacy = r#"{
+            "version": 1,
+            "input_hash": "abc123",
+            "file": "firmware.bin",
+            "fw2tar_command": ["fw2tar", "firmware.bin"],
+            "extractor": "unblob",
+            "devices": []
+        }"#;
+        let parsed: Manifest = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.secondary_filesystems.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Restores fw2tar's stable, front-facing output contract and populates the reserved `secondary_filesystems` manifest field from #70.

The recent winner-rename/delete redesign regressed the long-standing interface: it renamed the best extraction to `firmware.rootfs.tar.gz` and **deleted** the per-candidate `firmware.<extractor>.<N>.tar.gz` archives that consumers had coded against (still documented in the README). This PR treats that as a regression and brings the old contract back while keeping the newer convenience naming.

## Changes

**Output contract — "old names + keep the winner"**
- The winner is now **copied** (not renamed) to `firmware.rootfs.tar.gz`, so its per-candidate archive `firmware.<extractor>.<N>.tar.gz` stays in place. Every extractor × candidate archive is preserved.
- `--primary-limit > 1` secondaries are copied to `firmware.<N>.rootfs.tar.gz`.
- Cleanup no longer deletes candidate archives — only per-extractor `*.log` files (unless `--loud`). `cleanup_stray_artifacts` → `cleanup_extractor_logs`.

**Manifest — `secondary_filesystems` (#70), trailer/sidecar reconciled**
- `metadata.rs`: new `SecondaryFilesystem { index, archive }` and `Manifest.secondary_filesystems` (`skip_serializing_if` empty, so single-rootfs output stays byte-identical and legacy manifests still deserialize).
- The primary's manifest lists its secondaries by archive name relative to the primary, so consumers discover the full set without hardcoding filenames.
- `archive.rs`: new `append_manifest_trailer()`. The primary is a byte copy of a winning candidate whose embedded trailer predates the secondary list; when secondaries exist we append a reconciled gzip-member trailer so the **in-archive trailer == the `.manifest.json` sidecar**. This is what the trailer-reading consumers (`utils/show_metadata.py`, `utils/stitch`) actually read.

**Docs**
- `README.md`: reconciled the two previously-contradicting output descriptions into one coherent contract.

## Not included

`mounts` (the other reserved field in #70) is deliberately left out: fw2tar does not currently infer where a secondary mounts in the primary, so it needs a design decision (extraction-tree position vs. parsing `/etc/fstab` vs. leaving it to the consumer) before implementation.

## Tests

24 lib tests passing, including new coverage:
- `appended_trailer_supersedes_earlier_one` — reconciled trailer parses back to the manifest with secondaries (via `MultiGzDecoder`).
- `secondary_descriptor_records_relative_archive_name`, `empty_secondary_filesystems_omitted_from_json`, `populated_secondary_filesystems_round_trip`, `manifest_without_secondary_key_deserializes`.

Behavior harness is unaffected — it locates output via `find -name '*.rootfs.tar.gz'`, which still matches the winner and ignores the per-candidate archives; there is no output-dir cruft gate.

Closes #70 (secondary_filesystems half; `mounts` tracked separately).
